### PR TITLE
Updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ target/
 tmp/
 Cargo.lock
 .DS_Store
+*.swp
+*.swo

--- a/src/http/body.rs
+++ b/src/http/body.rs
@@ -41,6 +41,13 @@ impl IntoBody for String {
     }
 }
 
+impl IntoBody for Vec<u8> {
+    type IntoBody = BoundedBody<Vec<u8>>;
+    fn into_body(self) -> Self::IntoBody {
+        BoundedBody(Cursor::new(self))
+    }
+}
+
 impl<T> Body for T
 where
     T: AsyncRead,

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -27,7 +27,7 @@ impl<'a> Client<'a> {
         let res = wasi::http::outgoing_handler::handle(wasi_req, None).unwrap();
 
         // 2. Start sending the request body
-        io::copy(body, OutputStream::new(&self.reactor, body_stream))
+        io::copy(body, OutputStream::new(self.reactor, body_stream))
             .await
             .expect("io::copy broke oh no");
 
@@ -41,10 +41,7 @@ impl<'a> Client<'a> {
         // is to trap if we try and get the response more than once. The final
         // `?` is to raise the actual error if there is one.
         let res = res.get().unwrap().unwrap()?;
-        Ok(Response::try_from_incoming_response(
-            res,
-            self.reactor.clone(),
-        )?)
+        Response::try_from_incoming_response(res, self.reactor.clone())
     }
 }
 

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -19,7 +19,7 @@ impl<'a> Client<'a> {
 
     /// Send an HTTP request.
     pub async fn send<B: Body>(&self, req: Request<B>) -> Result<Response<IncomingBody>> {
-        let (wasi_req, body) = req.into_outgoing();
+        let (wasi_req, body) = req.try_into_outgoing()?;
         let wasi_body = wasi_req.body().unwrap();
         let body_stream = wasi_body.write().unwrap();
 

--- a/src/http/fields.rs
+++ b/src/http/fields.rs
@@ -70,6 +70,6 @@ impl TryFrom<Fields> for WasiFields {
                 list.push((name.clone().into_owned(), value));
             }
         }
-        Ok(WasiFields::from_list(&list)?)
+        WasiFields::from_list(&list)
     }
 }

--- a/src/http/fields.rs
+++ b/src/http/fields.rs
@@ -33,26 +33,18 @@ impl Fields {
     }
     pub fn contains(&self, key: &str) -> bool {
         self.0
-            .get(key)
+            .get(&key.to_lowercase())
             .is_some_and(|entry| !entry.values.is_empty())
     }
     pub fn get(&self, key: &str) -> Option<&[FieldValue]> {
-        if key.chars().any(|c| c.is_uppercase()) {
-            self.0
-                .get(&key.to_lowercase())
-                .map(|entry| entry.values.deref())
-        } else {
-            self.0.get(key).map(|entry| entry.values.deref())
-        }
+        self.0
+            .get(&key.to_lowercase())
+            .map(|entry| entry.values.deref())
     }
     pub fn get_mut(&mut self, key: &str) -> Option<&mut Vec<FieldValue>> {
-        if key.chars().any(|c| c.is_uppercase()) {
-            self.0
-                .get_mut(&key.to_lowercase())
-                .map(|entry| entry.values.as_mut())
-        } else {
-            self.0.get_mut(key).map(|entry| entry.values.as_mut())
-        }
+        self.0
+            .get_mut(&key.to_lowercase())
+            .map(|entry| entry.values.as_mut())
     }
     pub fn insert(&mut self, key: String, values: Vec<FieldValue>) {
         self.0
@@ -66,7 +58,7 @@ impl Fields {
         entry.values.push(value);
     }
     pub fn remove(&mut self, key: &str) -> Option<Vec<FieldValue>> {
-        self.0.remove(key).map(|entry| entry.values)
+        self.0.remove(&key.to_lowercase()).map(|entry| entry.values)
     }
 }
 

--- a/src/http/fields.rs
+++ b/src/http/fields.rs
@@ -1,5 +1,6 @@
+use super::Error;
 use std::{collections::HashMap, ops::Deref};
-use wasi::http::types::{Fields as WasiFields, HeaderError};
+use wasi::http::types::{ErrorCode, Fields as WasiFields, HeaderError};
 
 /// A type alias for [`Fields`] when used as HTTP headers.
 pub type Headers = Fields;
@@ -13,22 +14,68 @@ pub type FieldName = String;
 /// An HTTP Field value.
 pub type FieldValue = Vec<u8>;
 
+/// Field entry.
+#[derive(Clone, PartialEq, Eq)]
+pub(crate) struct FieldEntry {
+    /// Field key in original case.
+    key: String,
+    /// Field values.
+    values: Vec<FieldValue>,
+}
+
 /// HTTP Fields which can be used as either trailers or headers.
 #[derive(Clone, PartialEq, Eq)]
-pub struct Fields(pub(crate) HashMap<FieldName, Vec<FieldValue>>);
+pub struct Fields(pub(crate) HashMap<FieldName, FieldEntry>);
 
 impl Fields {
-    pub fn get(&self, k: &str) -> Option<&[FieldValue]> {
-        self.0.get(k).map(|f| f.deref())
+    pub(crate) fn new() -> Self {
+        Self(HashMap::new())
+    }
+    pub fn contains(&self, key: &str) -> bool {
+        self.0
+            .get(key)
+            .is_some_and(|entry| !entry.values.is_empty())
+    }
+    pub fn get(&self, key: &str) -> Option<&[FieldValue]> {
+        if key.chars().any(|c| c.is_uppercase()) {
+            self.0
+                .get(&key.to_lowercase())
+                .map(|entry| entry.values.deref())
+        } else {
+            self.0.get(key).map(|entry| entry.values.deref())
+        }
+    }
+    pub fn get_mut(&mut self, key: &str) -> Option<&mut Vec<FieldValue>> {
+        if key.chars().any(|c| c.is_uppercase()) {
+            self.0
+                .get_mut(&key.to_lowercase())
+                .map(|entry| entry.values.as_mut())
+        } else {
+            self.0.get_mut(key).map(|entry| entry.values.as_mut())
+        }
+    }
+    pub fn insert(&mut self, key: String, values: Vec<FieldValue>) {
+        self.0
+            .insert(key.to_lowercase(), FieldEntry { key, values });
+    }
+    pub fn append(&mut self, key: String, value: FieldValue) {
+        let entry: &mut FieldEntry = self.0.entry(key.to_lowercase()).or_insert(FieldEntry {
+            key,
+            values: Vec::with_capacity(1),
+        });
+        entry.values.push(value);
+    }
+    pub fn remove(&mut self, key: &str) -> Option<Vec<FieldValue>> {
+        self.0.remove(key).map(|entry| entry.values)
     }
 }
 
 impl std::fmt::Debug for Fields {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut map = f.debug_map();
-        let mut entries: Vec<_> = self.0.iter().collect();
-        entries.sort_by_cached_key(|(k, _)| k.to_owned());
-        for (key, values) in entries {
+        let mut entries: Vec<_> = self.0.values().collect();
+        entries.sort_by_cached_key(|entry| entry.key.to_owned());
+        for FieldEntry { key, values } in entries {
             match values.len() {
                 0 => {
                     map.entry(key, &"");
@@ -52,23 +99,34 @@ impl std::fmt::Debug for Fields {
 impl From<WasiFields> for Fields {
     fn from(wasi_fields: WasiFields) -> Self {
         let mut output = HashMap::new();
-        for (field_name, value) in wasi_fields.entries() {
-            let field_list: &mut Vec<_> = output.entry(field_name).or_default();
-            field_list.push(value);
+        for (key, value) in wasi_fields.entries() {
+            let field_name = key.to_lowercase();
+            let entry: &mut FieldEntry = output.entry(field_name).or_insert(FieldEntry {
+                key,
+                values: Vec::with_capacity(1),
+            });
+            entry.values.push(value);
         }
         Self(output)
     }
 }
 
 impl TryFrom<Fields> for WasiFields {
-    type Error = HeaderError;
+    type Error = Error;
     fn try_from(fields: Fields) -> Result<Self, Self::Error> {
-        let mut list = Vec::with_capacity(fields.0.capacity());
-        for (name, values) in fields.0.into_iter() {
+        let mut list = Vec::with_capacity(fields.0.values().map(|entry| entry.values.len()).sum());
+        for FieldEntry { key, values } in fields.0.into_values() {
             for value in values {
-                list.push((name.clone(), value));
+                list.push((key.clone(), value));
             }
         }
-        WasiFields::from_list(&list)
+        WasiFields::from_list(&list).map_err(|e| {
+            let msg = match e {
+                HeaderError::InvalidSyntax => "header has invalid syntax",
+                HeaderError::Forbidden => "header key is forbidden",
+                HeaderError::Immutable => "headers are immutable",
+            };
+            ErrorCode::InternalError(Some(msg.to_string()))
+        })
     }
 }

--- a/src/http/response.rs
+++ b/src/http/response.rs
@@ -53,11 +53,11 @@ impl Response<IncomingBody> {
         })
     }
 
-    /// NEEDS wasmtime PR to be released:
-    /// https://github.com/bytecodealliance/wasmtime/pull/9208
-    pub fn trailers(&self) -> Option<&Trailers> {
-        self.body.trailers.as_ref()
-    }
+    ///// NEEDS wasmtime PR to be released:
+    ///// https://github.com/bytecodealliance/wasmtime/pull/9208
+    //pub fn trailers(&self) -> Option<&Trailers> {
+    //    self.body.trailers.as_ref()
+    //}
     pub fn content_length(&self) -> Option<u64> {
         self.body.content_length
     }

--- a/src/http/response.rs
+++ b/src/http/response.rs
@@ -1,7 +1,7 @@
 use wasi::http::types::{IncomingBody as WasiIncomingBody, IncomingResponse};
 use wasi::io::streams::{InputStream, StreamError};
 
-use super::{Body, Headers, StatusCode};
+use super::{Body, Headers, StatusCode, Trailers};
 use crate::io::AsyncRead;
 use crate::runtime::Reactor;
 
@@ -13,55 +13,37 @@ pub struct Response<B: Body> {
     body: B,
 }
 
-// #[derive(Debug)]
-// enum BodyKind {
-//     Fixed(u64),
-//     Chunked,
-// }
-
-// impl BodyKind {
-//     fn from_headers(headers: &Fields) -> BodyKind {
-//         dbg!(&headers);
-//         if let Some(values) = headers.0.get("content-length") {
-//             let value = values
-//                 .get(0)
-//                 .expect("no value found for content-length; violates HTTP/1.1");
-//             let content_length = String::from_utf8(value.to_owned())
-//                 .unwrap()
-//                 .parse::<u64>()
-//                 .expect("content-length should be a u64; violates HTTP/1.1");
-//             BodyKind::Fixed(content_length)
-//         } else if let Some(values) = headers.0.get("transfer-encoding") {
-//             dbg!(values);
-//             BodyKind::Chunked
-//         } else {
-//             dbg!("Encoding neither has a content-length nor transfer-encoding");
-//             BodyKind::Chunked
-//         }
-//     }
-// }
-
 impl Response<IncomingBody> {
     pub(crate) fn try_from_incoming_response(
-        incoming: IncomingResponse,
+        incoming_response: IncomingResponse,
         reactor: Reactor,
     ) -> super::Result<Self> {
-        let headers: Headers = incoming.headers().into();
-        let status = incoming.status().into();
+        let headers: Headers = incoming_response.headers().into();
+        let status = incoming_response.status().into();
 
         // `body_stream` is a child of `incoming_body` which means we cannot
-        // drop the parent before we drop the child
-        let incoming_body = incoming
+        // drop the parent before we drop the child,
+        // which `incoming_body` is a child of `incoming_response`.
+        let incoming_body = incoming_response
             .consume()
             .expect("cannot call `consume` twice on incoming response");
         let body_stream = incoming_body
             .stream()
             .expect("cannot call `stream` twice on an incoming body");
 
+        let content_length = headers
+            .get("content-length")
+            .and_then(|vals| vals.first())
+            .and_then(|v| std::str::from_utf8(v).ok())
+            .and_then(|s| s.parse::<u64>().ok());
+
         let body = IncomingBody {
+            content_length,
             reactor,
-            body_stream,
-            _incoming_body: incoming_body,
+            trailers: None,
+            body_stream: Some(body_stream),
+            _incoming_body: Some(incoming_body),
+            _incoming_response: Some(incoming_response),
         };
 
         Ok(Self {
@@ -69,6 +51,15 @@ impl Response<IncomingBody> {
             body,
             status,
         })
+    }
+
+    /// NEEDS wasmtime PR to be released:
+    /// https://github.com/bytecodealliance/wasmtime/pull/9208
+    pub fn trailers(&self) -> Option<&Trailers> {
+        self.body.trailers.as_ref()
+    }
+    pub fn content_length(&self) -> Option<u64> {
+        self.body.content_length
     }
 }
 
@@ -97,28 +88,91 @@ impl<B: Body> Response<B> {
 #[derive(Debug)]
 pub struct IncomingBody {
     reactor: Reactor,
+    content_length: Option<u64>,
+    trailers: Option<Trailers>,
 
-    // IMPORTANT: the order of these fields here matters. `incoming_body` must
-    // be dropped before `body_stream`.
-    body_stream: InputStream,
-    _incoming_body: WasiIncomingBody,
+    // IMPORTANT: the order of these fields here matters.
+    // Rust drops `struct` fields in the order that they are defined in
+    // the source code.
+    //
+    // `body_stream` must be dropped before `incoming_body`, which
+    // must be dropped before `incoming_response`.
+    body_stream: Option<InputStream>,
+    _incoming_body: Option<WasiIncomingBody>,
+    _incoming_response: Option<IncomingResponse>,
+}
+
+impl IncomingBody {
+    /// Get the full response body as `Vec<u8>`.
+    pub async fn bytes(&mut self) -> crate::io::Result<Vec<u8>> {
+        let mut buf = Vec::with_capacity(self.content_length.unwrap_or_default() as usize);
+        self.read_to_end(&mut buf).await?;
+        Ok(buf)
+    }
 }
 
 impl AsyncRead for IncomingBody {
     async fn read(&mut self, buf: &mut [u8]) -> crate::io::Result<usize> {
-        // Wait for an event to be ready
-        self.reactor.wait_for(self.body_stream.subscribe()).await;
+        if let Some(stream) = self.body_stream.as_mut() {
+            // Wait for an event to be ready
+            self.reactor.wait_for(stream.subscribe()).await;
 
-        // Read the bytes from the body stream
-        let slice = match self.body_stream.read(buf.len() as u64) {
-            Ok(slice) => slice,
-            Err(StreamError::Closed) => return Ok(0),
-            Err(StreamError::LastOperationFailed(err)) => {
-                return Err(std::io::Error::other(err.to_debug_string()));
-            }
-        };
-        let bytes_read = slice.len();
-        buf[..bytes_read].copy_from_slice(&slice);
-        Ok(bytes_read)
+            // Read the bytes from the body stream
+            let slice = match stream.read(buf.len() as u64) {
+                Ok(slice) => slice,
+                Err(StreamError::Closed) => {
+                    // stream is done, follow drop order and finalize with trailers
+
+                    // drop `body_stream`
+                    let stream = self.body_stream.take();
+                    drop(stream);
+
+                    drop(
+                        self._incoming_body
+                            .take()
+                            .expect("IncomingBody is expected to be available"),
+                    );
+
+                    // finish `incoming_body` and get trailers
+                    // NEEDS wasmtime PR to be released:
+                    // https://github.com/bytecodealliance/wasmtime/pull/9208
+
+                    //let incoming_trailers = WasiIncomingBody::finish(
+                    //    self._incoming_body
+                    //        .take()
+                    //        .expect("IncomingBody is expected to be available"),
+                    //);
+                    //self.reactor.wait_for(incoming_trailers.subscribe()).await;
+                    //self.trailers = incoming_trailers
+                    //    .get()
+                    //    .unwrap() // succeeds since pollable is ready
+                    //    .unwrap() // succeeds since first time
+                    //    .or(Err(std::io::Error::other("Error receiving trailers")))?
+                    //    .map(|trailers| trailers.into());
+                    //drop(incoming_trailers);
+
+                    // drop `incoming_response`
+                    let incoming_response = self
+                        ._incoming_response
+                        .take()
+                        .expect("IncomingResponse is expected to be available");
+                    drop(incoming_response);
+
+                    // clear `content_length`
+                    self.content_length = None;
+
+                    return Ok(0);
+                }
+                Err(StreamError::LastOperationFailed(err)) => {
+                    return Err(std::io::Error::other(err.to_debug_string()));
+                }
+            };
+            let bytes_read = slice.len();
+            buf[..bytes_read].copy_from_slice(&slice);
+            Ok(bytes_read)
+        } else {
+            // stream is already closed
+            Ok(0)
+        }
     }
 }

--- a/src/http/response.rs
+++ b/src/http/response.rs
@@ -58,9 +58,6 @@ impl Response<IncomingBody> {
     //pub fn trailers(&self) -> Option<&Trailers> {
     //    self.body.trailers.as_ref()
     //}
-    pub fn content_length(&self) -> Option<u64> {
-        self.body.content_length
-    }
 }
 
 impl<B: Body> Response<B> {

--- a/src/http/response.rs
+++ b/src/http/response.rs
@@ -122,12 +122,13 @@ impl AsyncRead for IncomingBody {
                 self.reactor.wait_for(pollable).await;
 
                 // Read the bytes from the body stream
-                let buf = self.body_stream.read(CHUNK_SIZE).map_err(|err| match err {
-                    StreamError::LastOperationFailed(err) => {
-                        std::io::Error::other(format!("{}", err.to_debug_string()))
+                let buf = match self.body_stream.read(CHUNK_SIZE) {
+                    Ok(buf) => buf,
+                    Err(StreamError::Closed) => return Ok(0),
+                    Err(StreamError::LastOperationFailed(err)) => {
+                        return Err(std::io::Error::other(err.to_debug_string()));
                     }
-                    StreamError::Closed => std::io::Error::other("Connection closed"),
-                })?;
+                };
                 self.buf.insert(buf)
             }
         };

--- a/src/io/read.rs
+++ b/src/io/read.rs
@@ -1,6 +1,27 @@
 use crate::io;
 
+const CHUNK_SIZE: usize = 2048;
+
 /// Read bytes from a source.
 pub trait AsyncRead {
     async fn read(&mut self, buf: &mut [u8]) -> io::Result<usize>;
+    async fn read_to_end(&mut self, buf: &mut Vec<u8>) -> io::Result<usize> {
+        // total bytes written to buf
+        let mut n = 0;
+
+        loop {
+            // grow buf, if less than default chuck size
+            if buf.len() < n + CHUNK_SIZE {
+                buf.resize(n + CHUNK_SIZE, 0u8);
+            }
+
+            let len = self.read(&mut buf[n..]).await?;
+            if len == 0 {
+                buf.truncate(n);
+                return Ok(n);
+            }
+
+            n += len;
+        }
+    }
 }

--- a/src/io/read.rs
+++ b/src/io/read.rs
@@ -10,8 +10,8 @@ pub trait AsyncRead {
         let mut n = 0;
 
         loop {
-            // grow buf, if less than default chuck size
-            if buf.len() < n + CHUNK_SIZE {
+            // grow buf if empty
+            if buf.len() == n {
                 buf.resize(n + CHUNK_SIZE, 0u8);
             }
 

--- a/src/net/tcp_stream.rs
+++ b/src/net/tcp_stream.rs
@@ -32,9 +32,15 @@ impl<'a> TcpStream<'a> {
 impl<'a> AsyncRead for TcpStream<'a> {
     async fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         self.reactor.wait_for(self.input.subscribe()).await;
-        let slice = self.input.read(buf.len() as u64).map_err(to_io_err)?;
+        let slice = match self.input.read(buf.len() as u64) {
+            Ok(slice) => slice,
+            Err(StreamError::Closed) => return Ok(0),
+            Err(StreamError::LastOperationFailed(err)) => {
+                return Err(Error::other(err.to_debug_string()));
+            }
+        };
         let bytes_read = slice.len();
-        buf[..bytes_read].clone_from_slice(&slice);
+        buf[..bytes_read].copy_from_slice(&slice);
         Ok(bytes_read)
     }
 }
@@ -42,9 +48,15 @@ impl<'a> AsyncRead for TcpStream<'a> {
 impl<'a> AsyncRead for &TcpStream<'a> {
     async fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         self.reactor.wait_for(self.input.subscribe()).await;
-        let slice = self.input.read(buf.len() as u64).map_err(to_io_err)?;
+        let slice = match self.input.read(buf.len() as u64) {
+            Ok(slice) => slice,
+            Err(StreamError::Closed) => return Ok(0),
+            Err(StreamError::LastOperationFailed(err)) => {
+                return Err(Error::other(err.to_debug_string()));
+            }
+        };
         let bytes_read = slice.len();
-        buf[..bytes_read].clone_from_slice(&slice);
+        buf[..bytes_read].copy_from_slice(&slice);
         Ok(bytes_read)
     }
 }


### PR DESCRIPTION
- adds `read_to_end` to `AsyncRead` trait 
- adds methods for `Fields` (used for `Headers` and `Trailers`)

Getting the trailers on http response is commented out. The current release of wasmtime panics incorrectly. Made a NOTE in the source code. Can uncomment after https://github.com/bytecodealliance/wasmtime/pull/9208 is released.

Tested making outgoing requests with headers and reading the response.