### PR TITLE
thread Reactor through with a global

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ use wstd::net::TcpListener;
 use wstd::runtime::block_on;
 
 fn main() -> io::Result<()> {
-    block_on(|reactor| async move {
-        let listener = TcpListener::bind(&reactor, "127.0.0.1:8080").await?;
+    block_on(async move {
+        let listener = TcpListener::bind("127.0.0.1:8080").await?;
         println!("Listening on {}", listener.local_addr()?);
         println!("type `nc localhost 8080` to create a TCP client");
 

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -7,14 +7,12 @@ use crate::runtime::Reactor;
 
 /// An HTTP client.
 #[derive(Debug)]
-pub struct Client<'a> {
-    reactor: &'a Reactor,
-}
+pub struct Client {}
 
-impl<'a> Client<'a> {
+impl Client {
     /// Create a new instance of `Client`
-    pub fn new(reactor: &'a Reactor) -> Self {
-        Self { reactor }
+    pub fn new() -> Self {
+        Self {}
     }
 
     /// Send an HTTP request.
@@ -27,7 +25,7 @@ impl<'a> Client<'a> {
         let res = wasi::http::outgoing_handler::handle(wasi_req, None).unwrap();
 
         // 2. Start sending the request body
-        io::copy(body, OutputStream::new(&self.reactor, body_stream))
+        io::copy(body, OutputStream::new(body_stream))
             .await
             .expect("io::copy broke oh no");
 
@@ -36,42 +34,38 @@ impl<'a> Client<'a> {
         OutgoingBody::finish(wasi_body, trailers).unwrap();
 
         // 4. Receive the response
-        self.reactor.wait_for(res.subscribe()).await;
+        Reactor::current().wait_for(res.subscribe()).await;
         // NOTE: the first `unwrap` is to ensure readiness, the second `unwrap`
         // is to trap if we try and get the response more than once. The final
         // `?` is to raise the actual error if there is one.
         let res = res.get().unwrap().unwrap()?;
-        Ok(Response::try_from_incoming_response(
-            res,
-            self.reactor.clone(),
-        )?)
+        Ok(Response::try_from_incoming_response(res)?)
     }
 }
 
-struct OutputStream<'a> {
-    reactor: &'a Reactor,
+struct OutputStream {
     stream: wasi::http::types::OutputStream,
 }
 
-impl<'a> OutputStream<'a> {
-    fn new(reactor: &'a Reactor, stream: wasi::http::types::OutputStream) -> Self {
-        Self { reactor, stream }
+impl OutputStream {
+    fn new(stream: wasi::http::types::OutputStream) -> Self {
+        Self { stream }
     }
 }
 
-impl<'a> AsyncWrite for OutputStream<'a> {
+impl AsyncWrite for OutputStream {
     async fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         let max = self.stream.check_write().unwrap() as usize;
         let max = max.min(buf.len());
         let buf = &buf[0..max];
         self.stream.write(buf).unwrap();
-        self.reactor.wait_for(self.stream.subscribe()).await;
+        Reactor::current().wait_for(self.stream.subscribe()).await;
         Ok(max)
     }
 
     async fn flush(&mut self) -> io::Result<()> {
         self.stream.flush().unwrap();
-        self.reactor.wait_for(self.stream.subscribe()).await;
+        Reactor::current().wait_for(self.stream.subscribe()).await;
         Ok(())
     }
 }

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -6,6 +6,7 @@ use super::{response::IncomingBody, Body, Request, Response, Result};
 use crate::runtime::Reactor;
 
 /// An HTTP client.
+// Empty for now, but permits adding support for RequestOptions soon:
 #[derive(Debug)]
 pub struct Client {}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,8 +19,8 @@
 //! use wstd::runtime::block_on;
 //!
 //! fn main() -> io::Result<()> {
-//!     block_on(|reactor| async move {
-//!         let listener = TcpListener::bind(&reactor, "127.0.0.1:8080").await?;
+//!     block_on(async move {
+//!         let listener = TcpListener::bind("127.0.0.1:8080").await?;
 //!         println!("Listening on {}", listener.local_addr()?);
 //!         println!("type `nc localhost 8080` to create a TCP client");
 //!
@@ -56,12 +56,6 @@
 //! bytes. And `wstd::runtime` provides access to async runtime primitives.
 //! These are unique capabilities provided by WASI 0.2, and because this library
 //! is specific to that are exposed from here.
-//!
-//! Finally, this library does not implicitly thread through a
-//! [`Reactor`][runtime::Reactor] handle. Rather than using a `thread_local!`
-//! async resource APIs in `wstd` will borrow an instance of `Reactor`. This is
-//! a little more verbose, but in turn is a little simpler to implement,
-//! maintain, and extend.
 
 pub mod http;
 pub mod io;

--- a/src/net/tcp_stream.rs
+++ b/src/net/tcp_stream.rs
@@ -11,14 +11,13 @@ use crate::{
 };
 
 /// A TCP stream between a local and a remote socket.
-pub struct TcpStream<'a> {
-    pub(super) reactor: &'a Reactor,
+pub struct TcpStream {
     pub(super) input: InputStream,
     pub(super) output: OutputStream,
     pub(super) socket: TcpSocket,
 }
 
-impl<'a> TcpStream<'a> {
+impl TcpStream {
     /// Returns the socket address of the remote peer of this TCP connection.
     pub fn peer_addr(&self) -> io::Result<String> {
         let addr = self
@@ -29,9 +28,9 @@ impl<'a> TcpStream<'a> {
     }
 }
 
-impl<'a> AsyncRead for TcpStream<'a> {
+impl AsyncRead for TcpStream {
     async fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        self.reactor.wait_for(self.input.subscribe()).await;
+        Reactor::current().wait_for(self.input.subscribe()).await;
         let slice = self.input.read(buf.len() as u64).map_err(to_io_err)?;
         let bytes_read = slice.len();
         buf[..bytes_read].clone_from_slice(&slice);
@@ -39,9 +38,9 @@ impl<'a> AsyncRead for TcpStream<'a> {
     }
 }
 
-impl<'a> AsyncRead for &TcpStream<'a> {
+impl AsyncRead for &TcpStream {
     async fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        self.reactor.wait_for(self.input.subscribe()).await;
+        Reactor::current().wait_for(self.input.subscribe()).await;
         let slice = self.input.read(buf.len() as u64).map_err(to_io_err)?;
         let bytes_read = slice.len();
         buf[..bytes_read].clone_from_slice(&slice);
@@ -49,9 +48,9 @@ impl<'a> AsyncRead for &TcpStream<'a> {
     }
 }
 
-impl<'a> AsyncWrite for TcpStream<'a> {
+impl AsyncWrite for TcpStream {
     async fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.reactor.wait_for(self.output.subscribe()).await;
+        Reactor::current().wait_for(self.output.subscribe()).await;
         self.output.write(buf).map_err(to_io_err)?;
         Ok(buf.len())
     }
@@ -61,9 +60,9 @@ impl<'a> AsyncWrite for TcpStream<'a> {
     }
 }
 
-impl<'a> AsyncWrite for &TcpStream<'a> {
+impl AsyncWrite for &TcpStream {
     async fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.reactor.wait_for(self.output.subscribe()).await;
+        Reactor::current().wait_for(self.output.subscribe()).await;
         self.output.write(buf).map_err(to_io_err)?;
         Ok(buf.len())
     }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1,8 +1,8 @@
 //! Async event loop support.
 //!
-//! The way to use this is to call [`block_on()`] to obtain an instance of
-//! [`Reactor`]. You can then share the reactor in code that needs it to insert
-//! instances of
+//! The way to use this is to call [`block_on()`]. Inside the future, [`Reactor::current`]
+//! will give an instance of the [`Reactor`] running the event loop, which can be
+//! to [`Reactor::wait_for`] instances of
 //! [`wasi::Pollable`](https://docs.rs/wasi/latest/wasi/io/poll/struct.Pollable.html).
 //! This will automatically wait for the futures to resolve, and call the
 //! necessary wakers to work.
@@ -16,3 +16,10 @@ mod reactor;
 
 pub use block_on::block_on;
 pub use reactor::Reactor;
+use std::cell::RefCell;
+
+// There are no threads in WASI 0.2, so this is just a safe way to thread a single reactor to all
+// use sites in the background.
+std::thread_local! {
+pub(crate) static REACTOR: RefCell<Option<Reactor>> = RefCell::new(None);
+}

--- a/src/runtime/reactor.rs
+++ b/src/runtime/reactor.rs
@@ -1,4 +1,7 @@
-use super::polling::{EventKey, Poller};
+use super::{
+    polling::{EventKey, Poller},
+    REACTOR,
+};
 
 use core::cell::RefCell;
 use core::future;
@@ -23,6 +26,19 @@ struct InnerReactor {
 }
 
 impl Reactor {
+    /// Return a `Reactor` for the currently running `wstd::runtime::block_on`.
+    ///
+    /// # Panic
+    /// This will panic if called outside of `wstd::runtime::block_on`.
+    pub fn current() -> Self {
+        REACTOR.with(|r| {
+            r.borrow()
+                .as_ref()
+                .expect("Reactor::current must be called within a wstd runtime")
+                .clone()
+        })
+    }
+
     /// Create a new instance of `Reactor`
     pub(crate) fn new() -> Self {
         Self {

--- a/src/time/mod.rs
+++ b/src/time/mod.rs
@@ -36,32 +36,35 @@ impl SystemTime {
 }
 
 /// An async iterator representing notifications at fixed interval.
-pub fn interval(reactor: &Reactor, duration: Duration) -> Interval {
-    Interval { reactor, duration }
+pub fn interval(duration: Duration) -> Interval {
+    Interval { duration }
 }
 
 /// An async iterator representing notifications at fixed interval.
 ///
 /// See the [`interval`] function for more.
-pub struct Interval<'a> {
+pub struct Interval {
     duration: Duration,
-    reactor: &'a Reactor,
 }
-impl<'a> AsyncIterator for Interval<'a> {
+impl AsyncIterator for Interval {
     type Item = Instant;
 
     async fn next(&mut self) -> Option<Self::Item> {
-        wait_for(self.reactor, self.duration).await;
+        wait_for(self.duration).await;
         Some(Instant(wasi::clocks::monotonic_clock::now()))
     }
 }
 
 /// Wait until the passed duration has elapsed.
-pub async fn wait_for(reactor: &Reactor, duration: Duration) {
-    reactor.wait_for(subscribe_duration(duration.0)).await;
+pub async fn wait_for(duration: Duration) {
+    Reactor::current()
+        .wait_for(subscribe_duration(duration.0))
+        .await;
 }
 
 /// Wait until the passed instant.
-pub async fn wait_until(reactor: &Reactor, deadline: Instant) {
-    reactor.wait_for(subscribe_instant(deadline.0)).await;
+pub async fn wait_until(deadline: Instant) {
+    Reactor::current()
+        .wait_for(subscribe_instant(deadline.0))
+        .await;
 }


### PR DESCRIPTION
Instead of asking the user to thread a Reactor through their program, keep a singleton that is accessible via `Reactor::current()`. This accessor will panic when called outside of a `runtime::block_on`, which is a possible footgun that I don't think will be common in practice.

`wstd::runtime` now contains a `thread_local! { pub(crate) static REACTOR: RefCell<Option<Reactor>> }`. `runtime::block_on` populates the RefCell and clears it after the future completes, so it no longer takes a `FnOnce(Reactor) -> Fut` but just a plain `Future` argument. `Reactor::current` returns a clone (cheap, because Rc) of the reactor in the cell.

Eliminating the `&'a Reactor` from a bunch of structs, in favor of calling `Reactor::current()` at each use site, means we could eliminate the lifetime parameter from many of the structs.