### PR TITLE
http client: support request options

### DIFF
--- a/src/http/error.rs
+++ b/src/http/error.rs
@@ -9,6 +9,10 @@ pub struct Error {
     context: Vec<String>,
 }
 
+pub use http::header::{InvalidHeaderName, InvalidHeaderValue};
+pub use http::method::InvalidMethod;
+pub use wasi::http::types::{ErrorCode as WasiHttpErrorCode, HeaderError as WasiHttpHeaderError};
+
 impl fmt::Debug for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for c in self.context.iter() {
@@ -41,6 +45,9 @@ impl fmt::Display for Error {
 impl std::error::Error for Error {}
 
 impl Error {
+    pub fn variant(&self) -> &ErrorVariant {
+        &self.variant
+    }
     pub(crate) fn other(s: impl Into<String>) -> Self {
         ErrorVariant::Other(s.into()).into()
     }
@@ -63,42 +70,42 @@ impl From<ErrorVariant> for Error {
     }
 }
 
-impl From<wasi::http::types::ErrorCode> for Error {
-    fn from(e: wasi::http::types::ErrorCode) -> Error {
+impl From<WasiHttpErrorCode> for Error {
+    fn from(e: WasiHttpErrorCode) -> Error {
         ErrorVariant::WasiHttp(e).into()
     }
 }
 
-impl From<wasi::http::types::HeaderError> for Error {
-    fn from(e: wasi::http::types::HeaderError) -> Error {
+impl From<WasiHttpHeaderError> for Error {
+    fn from(e: WasiHttpHeaderError) -> Error {
         ErrorVariant::WasiHeader(e).into()
     }
 }
 
-impl From<http::header::InvalidHeaderValue> for Error {
-    fn from(e: http::header::InvalidHeaderValue) -> Error {
+impl From<InvalidHeaderValue> for Error {
+    fn from(e: InvalidHeaderValue) -> Error {
         ErrorVariant::HeaderValue(e).into()
     }
 }
 
-impl From<http::header::InvalidHeaderName> for Error {
-    fn from(e: http::header::InvalidHeaderName) -> Error {
+impl From<InvalidHeaderName> for Error {
+    fn from(e: InvalidHeaderName) -> Error {
         ErrorVariant::HeaderName(e).into()
     }
 }
 
-impl From<http::method::InvalidMethod> for Error {
-    fn from(e: http::method::InvalidMethod) -> Error {
+impl From<InvalidMethod> for Error {
+    fn from(e: InvalidMethod) -> Error {
         ErrorVariant::Method(e).into()
     }
 }
 
 #[derive(Debug)]
 pub enum ErrorVariant {
-    WasiHttp(wasi::http::types::ErrorCode),
-    WasiHeader(wasi::http::types::HeaderError),
-    HeaderName(http::header::InvalidHeaderName),
-    HeaderValue(http::header::InvalidHeaderValue),
-    Method(http::method::InvalidMethod),
+    WasiHttp(WasiHttpErrorCode),
+    WasiHeader(WasiHttpHeaderError),
+    HeaderName(InvalidHeaderName),
+    HeaderValue(InvalidHeaderValue),
+    Method(InvalidMethod),
     Other(String),
 }

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -15,7 +15,7 @@ pub use status_code::StatusCode;
 pub mod body;
 
 mod client;
-mod error;
+pub mod error;
 mod fields;
 mod method;
 mod request;

--- a/test-programs/src/bin/http_first_byte_timeout.rs
+++ b/test-programs/src/bin/http_first_byte_timeout.rs
@@ -1,0 +1,27 @@
+use wstd::http::{
+    error::{ErrorVariant, WasiHttpErrorCode},
+    Client, Method, Request,
+};
+
+#[wstd::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Set first byte timeout to 1/2 second.
+    let mut client = Client::new();
+    client.set_first_byte_timeout(std::time::Duration::from_millis(500));
+    // This get request will connect to the server, which will then wait 1 second before
+    // returning a response.
+    let request = Request::new(Method::GET, "https://postman-echo.com/delay/1".parse()?);
+    let result = client.send(request).await;
+
+    assert!(result.is_err(), "response should be an error");
+    let error = result.unwrap_err();
+    assert!(
+        matches!(
+            error.variant(),
+            ErrorVariant::WasiHttp(WasiHttpErrorCode::ConnectionReadTimeout)
+        ),
+        "expected ConnectionReadTimeout error, got: {error:?>}"
+    );
+
+    Ok(())
+}

--- a/tests/test-programs.rs
+++ b/tests/test-programs.rs
@@ -124,6 +124,16 @@ fn tcp_echo_server() -> Result<()> {
 fn http_get() -> Result<()> {
     println!("testing {}", test_programs_artifacts::HTTP_GET);
     let wasm = std::fs::read(test_programs_artifacts::HTTP_GET).context("read wasm")?;
+    run_in_wasmtime(&wasm, None)
+}
 
+#[test]
+fn http_first_byte_timeout() -> Result<()> {
+    println!(
+        "testing {}",
+        test_programs_artifacts::HTTP_FIRST_BYTE_TIMEOUT
+    );
+    let wasm =
+        std::fs::read(test_programs_artifacts::HTTP_FIRST_BYTE_TIMEOUT).context("read wasm")?;
     run_in_wasmtime(&wasm, None)
 }


### PR DESCRIPTION
test first byte timeout against postman-echo.com/delay

and re-export all the error types in http::error.

Closes #14 