### PR TITLE
Reactor::wait_for takes `&Pollable` instead of `Pollable`

### DIFF
--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -36,7 +36,7 @@ impl Client {
         OutgoingBody::finish(wasi_body, trailers).unwrap();
 
         // 4. Receive the response
-        Reactor::current().wait_for(res.subscribe()).await;
+        Reactor::current().wait_for(&res.subscribe()).await;
         // NOTE: the first `unwrap` is to ensure readiness, the second `unwrap`
         // is to trap if we try and get the response more than once. The final
         // `?` is to raise the actual error if there is one.
@@ -90,13 +90,13 @@ impl AsyncWrite for OutputStream {
         let max = max.min(buf.len());
         let buf = &buf[0..max];
         self.stream.write(buf).unwrap();
-        Reactor::current().wait_for(self.stream.subscribe()).await;
+        Reactor::current().wait_for(&self.stream.subscribe()).await;
         Ok(max)
     }
 
     async fn flush(&mut self) -> io::Result<()> {
         self.stream.flush().unwrap();
-        Reactor::current().wait_for(self.stream.subscribe()).await;
+        Reactor::current().wait_for(&self.stream.subscribe()).await;
         Ok(())
     }
 }

--- a/src/http/response.rs
+++ b/src/http/response.rs
@@ -113,7 +113,7 @@ impl AsyncRead for IncomingBody {
             None => {
                 // Wait for an event to be ready
                 let pollable = self.body_stream.subscribe();
-                Reactor::current().wait_for(pollable).await;
+                Reactor::current().wait_for(&pollable).await;
 
                 // Read the bytes from the body stream
                 let buf = match self.body_stream.read(CHUNK_SIZE) {

--- a/src/net/tcp_listener.rs
+++ b/src/net/tcp_listener.rs
@@ -45,11 +45,11 @@ impl TcpListener {
         socket
             .start_bind(&network, local_address)
             .map_err(to_io_err)?;
-        reactor.wait_for(socket.subscribe()).await;
+        reactor.wait_for(&socket.subscribe()).await;
         socket.finish_bind().map_err(to_io_err)?;
 
         socket.start_listen().map_err(to_io_err)?;
-        reactor.wait_for(socket.subscribe()).await;
+        reactor.wait_for(&socket.subscribe()).await;
         socket.finish_listen().map_err(to_io_err)?;
         Ok(Self { socket })
     }
@@ -78,7 +78,7 @@ impl<'a> AsyncIterator for Incoming<'a> {
 
     async fn next(&mut self) -> Option<Self::Item> {
         Reactor::current()
-            .wait_for(self.listener.socket.subscribe())
+            .wait_for(&self.listener.socket.subscribe())
             .await;
         let (socket, input, output) = match self.listener.socket.accept().map_err(to_io_err) {
             Ok(accepted) => accepted,

--- a/src/net/tcp_stream.rs
+++ b/src/net/tcp_stream.rs
@@ -30,7 +30,7 @@ impl TcpStream {
 
 impl AsyncRead for TcpStream {
     async fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        Reactor::current().wait_for(self.input.subscribe()).await;
+        Reactor::current().wait_for(&self.input.subscribe()).await;
         let slice = match self.input.read(buf.len() as u64) {
             Ok(slice) => slice,
             Err(StreamError::Closed) => return Ok(0),
@@ -44,7 +44,7 @@ impl AsyncRead for TcpStream {
 
 impl AsyncRead for &TcpStream {
     async fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        Reactor::current().wait_for(self.input.subscribe()).await;
+        Reactor::current().wait_for(&self.input.subscribe()).await;
         let slice = match self.input.read(buf.len() as u64) {
             Ok(slice) => slice,
             Err(StreamError::Closed) => return Ok(0),
@@ -58,7 +58,7 @@ impl AsyncRead for &TcpStream {
 
 impl AsyncWrite for TcpStream {
     async fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        Reactor::current().wait_for(self.output.subscribe()).await;
+        Reactor::current().wait_for(&self.output.subscribe()).await;
         self.output.write(buf).map_err(to_io_err)?;
         Ok(buf.len())
     }
@@ -70,7 +70,7 @@ impl AsyncWrite for TcpStream {
 
 impl AsyncWrite for &TcpStream {
     async fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        Reactor::current().wait_for(self.output.subscribe()).await;
+        Reactor::current().wait_for(&self.output.subscribe()).await;
         self.output.write(buf).map_err(to_io_err)?;
         Ok(buf.len())
     }

--- a/src/time/mod.rs
+++ b/src/time/mod.rs
@@ -67,7 +67,7 @@ impl Timer {
         match self.0 {
             Some(deadline) => {
                 Reactor::current()
-                    .wait_for(subscribe_instant(*deadline))
+                    .wait_for(&subscribe_instant(*deadline))
                     .await
             }
             None => std::future::pending().await,


### PR DESCRIPTION
We want to be able to reuse a pollable on many uses in the reactor.

The fundamental underlying operation `wasi:io/poll.poll` takes a `list<borrow<pollable>>`, or `&[&Pollable]` in Rust.

The `Poller` structure needs to be changed to unsafe transmute the `&Pollable` to a common lifetime for passing to `poll`. This remains safe as long as each caller that inserts a `&Pollable` unconditionally removes it.