### PR TITLE
Introduce AsyncInputStream, AsyncOutputStream, and stdio

### DIFF
--- a/src/http/error.rs
+++ b/src/http/error.rs
@@ -24,6 +24,7 @@ impl fmt::Debug for Error {
             ErrorVariant::HeaderName(e) => write!(f, "header name error: {e:?}"),
             ErrorVariant::HeaderValue(e) => write!(f, "header value error: {e:?}"),
             ErrorVariant::Method(e) => write!(f, "method error: {e:?}"),
+            ErrorVariant::BodyIo(e) => write!(f, "body error: {e:?}"),
             ErrorVariant::Other(e) => write!(f, "{e}"),
         }
     }
@@ -37,6 +38,7 @@ impl fmt::Display for Error {
             ErrorVariant::HeaderName(e) => write!(f, "header name error: {e}"),
             ErrorVariant::HeaderValue(e) => write!(f, "header value error: {e}"),
             ErrorVariant::Method(e) => write!(f, "method error: {e}"),
+            ErrorVariant::BodyIo(e) => write!(f, "body error: {e}"),
             ErrorVariant::Other(e) => write!(f, "{e}"),
         }
     }
@@ -100,6 +102,12 @@ impl From<InvalidMethod> for Error {
     }
 }
 
+impl From<std::io::Error> for Error {
+    fn from(e: std::io::Error) -> Error {
+        ErrorVariant::BodyIo(e).into()
+    }
+}
+
 #[derive(Debug)]
 pub enum ErrorVariant {
     WasiHttp(WasiHttpErrorCode),
@@ -107,5 +115,6 @@ pub enum ErrorVariant {
     HeaderName(InvalidHeaderName),
     HeaderValue(InvalidHeaderValue),
     Method(InvalidMethod),
+    BodyIo(std::io::Error),
     Other(String),
 }

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -5,13 +5,16 @@ mod cursor;
 mod empty;
 mod read;
 mod seek;
+mod streams;
 mod write;
 
+pub use crate::runtime::AsyncPollable;
 pub use copy::*;
 pub use cursor::*;
 pub use empty::*;
 pub use read::*;
 pub use seek::*;
+pub use streams::*;
 pub use write::*;
 
 /// The error type for I/O operations.

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -5,6 +5,7 @@ mod cursor;
 mod empty;
 mod read;
 mod seek;
+mod stdio;
 mod streams;
 mod write;
 
@@ -14,6 +15,7 @@ pub use cursor::*;
 pub use empty::*;
 pub use read::*;
 pub use seek::*;
+pub use stdio::*;
 pub use streams::*;
 pub use write::*;
 

--- a/src/io/stdio.rs
+++ b/src/io/stdio.rs
@@ -1,0 +1,136 @@
+use super::{AsyncInputStream, AsyncOutputStream};
+use std::cell::LazyCell;
+use wasi::cli::terminal_input::TerminalInput;
+use wasi::cli::terminal_output::TerminalOutput;
+
+/// Use the program's stdin as an `AsyncInputStream`.
+pub struct Stdin {
+    stream: AsyncInputStream,
+    terminput: LazyCell<Option<TerminalInput>>,
+}
+
+/// Get the program's stdin for use as an `AsyncInputStream`.
+pub fn stdin() -> Stdin {
+    let stream = AsyncInputStream::new(wasi::cli::stdin::get_stdin());
+    Stdin {
+        stream,
+        terminput: LazyCell::new(|| wasi::cli::terminal_stdin::get_terminal_stdin()),
+    }
+}
+
+impl std::ops::Deref for Stdin {
+    type Target = AsyncInputStream;
+    fn deref(&self) -> &AsyncInputStream {
+        &self.stream
+    }
+}
+impl std::ops::DerefMut for Stdin {
+    fn deref_mut(&mut self) -> &mut AsyncInputStream {
+        &mut self.stream
+    }
+}
+
+impl Stdin {
+    /// Check if stdin is a terminal.
+    pub fn is_terminal(&self) -> bool {
+        LazyCell::force(&self.terminput).is_some()
+    }
+}
+
+/// Use the program's stdout as an `AsyncOutputStream`.
+pub struct Stdout {
+    stream: AsyncOutputStream,
+    termoutput: LazyCell<Option<TerminalOutput>>,
+}
+
+/// Get the program's stdout for use as an `AsyncOutputStream`.
+pub fn stdout() -> Stdout {
+    let stream = AsyncOutputStream::new(wasi::cli::stdout::get_stdout());
+    Stdout {
+        stream,
+        termoutput: LazyCell::new(|| wasi::cli::terminal_stdout::get_terminal_stdout()),
+    }
+}
+
+impl Stdout {
+    /// Check if stdout is a terminal.
+    pub fn is_terminal(&self) -> bool {
+        LazyCell::force(&self.termoutput).is_some()
+    }
+}
+
+impl std::ops::Deref for Stdout {
+    type Target = AsyncOutputStream;
+    fn deref(&self) -> &AsyncOutputStream {
+        &self.stream
+    }
+}
+impl std::ops::DerefMut for Stdout {
+    fn deref_mut(&mut self) -> &mut AsyncOutputStream {
+        &mut self.stream
+    }
+}
+
+/// Use the program's stdout as an `AsyncOutputStream`.
+pub struct Stderr {
+    stream: AsyncOutputStream,
+    termoutput: LazyCell<Option<TerminalOutput>>,
+}
+
+/// Get the program's stdout for use as an `AsyncOutputStream`.
+pub fn stderr() -> Stderr {
+    let stream = AsyncOutputStream::new(wasi::cli::stderr::get_stderr());
+    Stderr {
+        stream,
+        termoutput: LazyCell::new(|| wasi::cli::terminal_stderr::get_terminal_stderr()),
+    }
+}
+
+impl Stderr {
+    /// Check if stderr is a terminal.
+    pub fn is_terminal(&self) -> bool {
+        LazyCell::force(&self.termoutput).is_some()
+    }
+}
+
+impl std::ops::Deref for Stderr {
+    type Target = AsyncOutputStream;
+    fn deref(&self) -> &AsyncOutputStream {
+        &self.stream
+    }
+}
+impl std::ops::DerefMut for Stderr {
+    fn deref_mut(&mut self) -> &mut AsyncOutputStream {
+        &mut self.stream
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::io::AsyncWrite;
+    use crate::runtime::block_on;
+    #[test]
+    // No internal predicate. Run test with --nocapture and inspect output manually.
+    fn stdout_println_hello_world() {
+        block_on(async {
+            let mut stdout = super::stdout();
+            let term = if stdout.is_terminal() { "is" } else { "is not" };
+            stdout
+                .write_all(format!("hello, world! stdout {term} a terminal\n",).as_bytes())
+                .await
+                .unwrap();
+        })
+    }
+    #[test]
+    // No internal predicate. Run test with --nocapture and inspect output manually.
+    fn stderr_println_hello_world() {
+        block_on(async {
+            let mut stdout = super::stdout();
+            let term = if stdout.is_terminal() { "is" } else { "is not" };
+            stdout
+                .write_all(format!("hello, world! stderr {term} a terminal\n",).as_bytes())
+                .await
+                .unwrap();
+        })
+    }
+}

--- a/src/io/stdio.rs
+++ b/src/io/stdio.rs
@@ -4,6 +4,7 @@ use wasi::cli::terminal_input::TerminalInput;
 use wasi::cli::terminal_output::TerminalOutput;
 
 /// Use the program's stdin as an `AsyncInputStream`.
+#[derive(Debug)]
 pub struct Stdin {
     stream: AsyncInputStream,
     terminput: LazyCell<Option<TerminalInput>>,
@@ -38,6 +39,7 @@ impl Stdin {
 }
 
 /// Use the program's stdout as an `AsyncOutputStream`.
+#[derive(Debug)]
 pub struct Stdout {
     stream: AsyncOutputStream,
     termoutput: LazyCell<Option<TerminalOutput>>,
@@ -72,6 +74,7 @@ impl std::ops::DerefMut for Stdout {
 }
 
 /// Use the program's stdout as an `AsyncOutputStream`.
+#[derive(Debug)]
 pub struct Stderr {
     stream: AsyncOutputStream,
     termoutput: LazyCell<Option<TerminalOutput>>,

--- a/src/io/streams.rs
+++ b/src/io/streams.rs
@@ -1,0 +1,123 @@
+use super::{AsyncPollable, AsyncRead, AsyncWrite};
+use std::cell::RefCell;
+use std::io::Result;
+use wasi::io::streams::{InputStream, OutputStream, StreamError};
+
+pub struct AsyncInputStream {
+    // Lazily initialized pollable, used for lifetime of stream to check readiness.
+    // Field ordering matters: this child must be dropped before stream
+    subscription: RefCell<Option<AsyncPollable>>,
+    stream: InputStream,
+}
+
+impl AsyncInputStream {
+    pub fn new(stream: InputStream) -> Self {
+        Self {
+            subscription: RefCell::new(None),
+            stream,
+        }
+    }
+    async fn ready(&self) {
+        // Lazily initialize the AsyncPollable
+        if self.subscription.borrow().is_none() {
+            self.subscription
+                .replace(Some(AsyncPollable::new(self.stream.subscribe())));
+        }
+        // Wait on readiness
+        self.subscription
+            .borrow()
+            .as_ref()
+            .expect("populated refcell")
+            .wait_for()
+            .await;
+    }
+}
+
+impl AsyncRead for AsyncInputStream {
+    async fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
+        self.ready().await;
+        // Ideally, the ABI would be able to read directly into buf. However, with the default
+        // generated bindings, it returns a newly allocated vec, which we need to copy into buf.
+        let read = match self.stream.read(buf.len() as u64) {
+            Ok(r) => r,
+            Err(StreamError::Closed) => return Ok(0),
+            Err(StreamError::LastOperationFailed(err)) => {
+                return Err(std::io::Error::other(err.to_debug_string()))
+            }
+        };
+        let len = read.len();
+        buf[0..len].copy_from_slice(&read);
+        Ok(len)
+    }
+}
+
+pub struct AsyncOutputStream {
+    // Lazily initialized pollable, used for lifetime of stream to check readiness.
+    // Field ordering matters: this child must be dropped before stream
+    subscription: RefCell<Option<AsyncPollable>>,
+    stream: OutputStream,
+}
+
+impl AsyncOutputStream {
+    pub fn new(stream: OutputStream) -> Self {
+        Self {
+            subscription: RefCell::new(None),
+            stream,
+        }
+    }
+    async fn ready(&self) {
+        // Lazily initialize the AsyncPollable
+        if self.subscription.borrow().is_none() {
+            self.subscription
+                .replace(Some(AsyncPollable::new(self.stream.subscribe())));
+        }
+        // Wait on readiness
+        self.subscription
+            .borrow()
+            .as_ref()
+            .expect("populated refcell")
+            .wait_for()
+            .await;
+    }
+}
+impl AsyncWrite for AsyncOutputStream {
+    // Required methods
+    async fn write(&mut self, buf: &[u8]) -> Result<usize> {
+        // Loops at most twice.
+        loop {
+            match self.stream.check_write() {
+                Ok(0) => {
+                    self.ready().await;
+                    // Next loop guaranteed to have nonzero check_write, or error.
+                    continue;
+                }
+                Ok(some) => {
+                    let writable = some.try_into().unwrap_or(usize::MAX).min(buf.len());
+                    match self.stream.write(&buf[0..writable]) {
+                        Ok(()) => return Ok(writable),
+                        Err(StreamError::Closed) => return Ok(0),
+                        Err(StreamError::LastOperationFailed(err)) => {
+                            return Err(std::io::Error::other(err.to_debug_string()))
+                        }
+                    }
+                }
+                Err(StreamError::Closed) => return Ok(0),
+                Err(StreamError::LastOperationFailed(err)) => {
+                    return Err(std::io::Error::other(err.to_debug_string()))
+                }
+            }
+        }
+    }
+    async fn flush(&mut self) -> Result<()> {
+        match self.stream.flush() {
+            Ok(()) => {
+                self.ready().await;
+                Ok(())
+            }
+            Err(StreamError::Closed) => Ok(()),
+            Err(StreamError::LastOperationFailed(err)) => {
+                Err(std::io::Error::other(err.to_debug_string()))
+            }
+        }
+    }
+}

--- a/src/io/streams.rs
+++ b/src/io/streams.rs
@@ -3,6 +3,7 @@ use std::cell::RefCell;
 use std::io::Result;
 use wasi::io::streams::{InputStream, OutputStream, StreamError};
 
+#[derive(Debug)]
 pub struct AsyncInputStream {
     // Lazily initialized pollable, used for lifetime of stream to check readiness.
     // Field ordering matters: this child must be dropped before stream
@@ -51,6 +52,7 @@ impl AsyncRead for AsyncInputStream {
     }
 }
 
+#[derive(Debug)]
 pub struct AsyncOutputStream {
     // Lazily initialized pollable, used for lifetime of stream to check readiness.
     // Field ordering matters: this child must be dropped before stream

--- a/src/runtime/reactor.rs
+++ b/src/runtime/reactor.rs
@@ -33,6 +33,11 @@ impl Drop for Registration {
 pub struct AsyncPollable(Rc<Registration>);
 
 impl AsyncPollable {
+    /// Create an `AsyncPollable` from a Wasi `Pollable`. Schedules the `Pollable` with the current
+    /// `Reactor`.
+    pub fn new(pollable: Pollable) -> Self {
+        Reactor::current().schedule(pollable)
+    }
     /// Create a Future that waits for the Pollable's readiness.
     pub fn wait_for(&self) -> WaitFor {
         use std::sync::atomic::{AtomicUsize, Ordering};


### PR DESCRIPTION
and convert all of the crate's uses of InputStream/OutputStream/Pollable to use their Async wrappers.

* new io::stdio mod introduces Stdin, Stdout, Stderr, which are wrappers (via DerefMut, is that poor form?) of AsyncInputStream / AsyncOutputStream. There's a test that has to be checked by hand by running in `--nocapture` for each of stdout and stderr, but no test for stdin yet. That will have to be written in the style of the tcp echo server test, in a future PR.
* http::Request uses an AsyncOutputStream for writing body
* http::IncomingBody uses an AsyncInputStream for reading body
* net::TcpListener uses an AsyncPollable to await readiness with a single Pollable lasting the lifetime of the listener
* net::TcpStream uses AsyncInputStream and AsyncOutputStream for read/write

Closes #23 