### PR TITLE
Minor fixes, and release 0.5.0-draft2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.5.0-draft1"
+version = "0.5.0-draft2"
 edition = "2021"
 license = "MIT OR Apache-2.0 OR Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/yoshuawuyts/wstd"
@@ -65,4 +65,4 @@ wasmtime = "26"
 wasmtime-wasi = "26"
 wasmtime-wasi-http = "26"
 wstd = { path = "." }
-wstd-macro = { path = "macro", version = "=0.5.0-draft1" }
+wstd-macro = { path = "macro", version = "=0.5.0-draft2" }

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -1,6 +1,5 @@
 use super::{response::IncomingBody, Body, Error, Request, Response, Result};
-use crate::io::{self, AsyncOutputStream};
-use crate::runtime::Reactor;
+use crate::io::{self, AsyncOutputStream, AsyncPollable};
 use crate::time::Duration;
 use wasi::http::types::{OutgoingBody, RequestOptions as WasiRequestOptions};
 
@@ -34,7 +33,8 @@ impl Client {
         OutgoingBody::finish(wasi_body, trailers).unwrap();
 
         // 4. Receive the response
-        Reactor::current().wait_for(res.subscribe()).await;
+        AsyncPollable::new(res.subscribe()).wait_for().await;
+
         // NOTE: the first `unwrap` is to ensure readiness, the second `unwrap`
         // is to trap if we try and get the response more than once. The final
         // `?` is to raise the actual error if there is one.

--- a/src/runtime/reactor.rs
+++ b/src/runtime/reactor.rs
@@ -207,12 +207,6 @@ impl Reactor {
         }
         ready
     }
-
-    /// Wait for the pollable to resolve.
-    pub async fn wait_for(&self, pollable: Pollable) {
-        let p = self.schedule(pollable);
-        p.wait_for().await
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
* Add minor forgotten change from #37
* Eliminate Reactor::wait_for, to point users towards the superior AsyncPollable::wait_for.
* Bump version to 0.5.0-draft2