### PR TITLE
Implement `AsyncRead`/`AsyncWrite` for `&mut T`.

### DIFF
--- a/src/io/read.rs
+++ b/src/io/read.rs
@@ -25,3 +25,15 @@ pub trait AsyncRead {
         }
     }
 }
+
+impl<R: AsyncRead + ?Sized> AsyncRead for &mut R {
+    #[inline]
+    async fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        (*self).read(buf).await
+    }
+
+    #[inline]
+    async fn read_to_end(&mut self, buf: &mut Vec<u8>) -> io::Result<usize> {
+        (*self).read_to_end(buf).await
+    }
+}

--- a/src/io/write.rs
+++ b/src/io/write.rs
@@ -17,3 +17,20 @@ pub trait AsyncWrite {
         }
     }
 }
+
+impl<W: AsyncWrite + ?Sized> AsyncWrite for &mut W {
+    #[inline]
+    async fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        (*self).write(buf).await
+    }
+
+    #[inline]
+    async fn flush(&mut self) -> io::Result<()> {
+        (*self).flush().await
+    }
+
+    #[inline]
+    async fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
+        (*self).write_all(buf).await
+    }
+}


### PR DESCRIPTION
Provide blanket implementations:
 - `impl<R: AsyncRead + ?Sized> AsyncRead for &mut R` and
 - `impl<W: AsyncWrite + ?Sized> AsyncWrite for &mut W`

This is similar to what is done for similar traits in `std::io` ([`Read`](https://doc.rust-lang.org/stable/std/io/trait.Read.html#impl-Read-for-%26mut+R), [`Write`](https://doc.rust-lang.org/stable/std/io/trait.Write.html#impl-Write-for-%26mut+W)), `futures-io` ([`AsyncRead`](https://docs.rs/futures-io/latest/futures_io/trait.AsyncRead.html#impl-AsyncRead-for-%26mut+T), [`AsyncWrite`](https://docs.rs/futures-io/latest/futures_io/trait.AsyncWrite.html#impl-AsyncWrite-for-%26mut+T)), and `tokio` ([`AsyncRead`](https://docs.rs/tokio/latest/tokio/io/trait.AsyncRead.html#impl-AsyncRead-for-%26mut+T), [`AsyncWrite`](https://docs.rs/tokio/latest/tokio/io/trait.AsyncWrite.html#impl-AsyncWrite-for-%26mut+T)).