### PR TITLE
Rename `into_outgoing` and `try_into_incoming_response` for consistency

### DIFF
--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -1,6 +1,6 @@
 use super::{body::IncomingBody, Body, Error, Request, Response, Result};
-use crate::http::request::into_outgoing;
-use crate::http::response::try_from_incoming_response;
+use crate::http::request::try_into_outgoing;
+use crate::http::response::try_from_incoming;
 use crate::io::{self, AsyncOutputStream, AsyncPollable};
 use crate::time::Duration;
 use wasi::http::types::{OutgoingBody, RequestOptions as WasiRequestOptions};
@@ -20,7 +20,7 @@ impl Client {
 
     /// Send an HTTP request.
     pub async fn send<B: Body>(&self, req: Request<B>) -> Result<Response<IncomingBody>> {
-        let (wasi_req, body) = into_outgoing(req)?;
+        let (wasi_req, body) = try_into_outgoing(req)?;
         let wasi_body = wasi_req.body().unwrap();
         let body_stream = wasi_body.write().unwrap();
 
@@ -41,7 +41,7 @@ impl Client {
         // is to trap if we try and get the response more than once. The final
         // `?` is to raise the actual error if there is one.
         let res = res.get().unwrap().unwrap()?;
-        try_from_incoming_response(res)
+        try_from_incoming(res)
     }
 
     /// Set timeout on connecting to HTTP server

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -4,7 +4,7 @@ use wasi::http::types::Scheme;
 
 pub use http::Request;
 
-pub(crate) fn into_outgoing<T>(request: Request<T>) -> Result<(OutgoingRequest, T)> {
+pub(crate) fn try_into_outgoing<T>(request: Request<T>) -> Result<(OutgoingRequest, T)> {
     let wasi_req = OutgoingRequest::new(header_map_to_wasi(request.headers())?);
 
     let (parts, body) = request.into_parts();

--- a/src/http/response.rs
+++ b/src/http/response.rs
@@ -10,9 +10,7 @@ use http::StatusCode;
 
 pub use http::Response;
 
-pub(crate) fn try_from_incoming_response(
-    incoming: IncomingResponse,
-) -> Result<Response<IncomingBody>> {
+pub(crate) fn try_from_incoming(incoming: IncomingResponse) -> Result<Response<IncomingBody>> {
     let headers: HeaderMap = header_map_from_wasi(incoming.headers())?;
     // TODO: Does WASI guarantee that the incoming status is valid?
     let status =


### PR DESCRIPTION
Rename `request::into_outgoing` to `request::try_into_outgoing`, and `response::try_into_incoming_response` to `response::try_into_incoming` for consistency.