### PR TITLE
Optimize copy.

### DIFF
--- a/src/http/body.rs
+++ b/src/http/body.rs
@@ -139,6 +139,10 @@ impl AsyncRead for IncomingBody {
     async fn read(&mut self, out_buf: &mut [u8]) -> crate::io::Result<usize> {
         self.body_stream.read(out_buf).await
     }
+
+    fn as_async_input_stream(&self) -> Option<&AsyncInputStream> {
+        Some(&self.body_stream)
+    }
 }
 
 impl Body for IncomingBody {

--- a/src/io/copy.rs
+++ b/src/io/copy.rs
@@ -1,4 +1,5 @@
-use crate::io::{AsyncRead, AsyncWrite};
+use crate::io::{AsyncRead, AsyncWrite, Error};
+use wasi::io::streams::StreamError;
 
 /// Copy bytes from a reader to a writer.
 pub async fn copy<R, W>(mut reader: R, mut writer: W) -> crate::io::Result<()>
@@ -6,6 +7,23 @@ where
     R: AsyncRead,
     W: AsyncWrite,
 {
+    // Optimized path when we have an `AsyncInputStream` and an
+    // `AsyncOutputStream`.
+    if let Some(reader) = reader.as_async_input_stream() {
+        if let Some(writer) = writer.as_async_output_stream() {
+            loop {
+                match super::splice(reader, writer, u64::MAX).await {
+                    Ok(_n) => (),
+                    Err(StreamError::Closed) => return Ok(()),
+                    Err(StreamError::LastOperationFailed(err)) => {
+                        return Err(Error::other(err.to_debug_string()));
+                    }
+                }
+            }
+        }
+    }
+
+    // Unoptimized case: read the input and then write it.
     let mut buf = [0; 1024];
     'read: loop {
         let bytes_read = reader.read(&mut buf).await?;

--- a/src/io/read.rs
+++ b/src/io/read.rs
@@ -24,16 +24,28 @@ pub trait AsyncRead {
             n += len;
         }
     }
+
+    // If the `AsyncRead` implementation is an unbuffered wrapper around an
+    // `AsyncInputStream`, some I/O operations can be more efficient.
+    #[inline]
+    fn as_async_input_stream(&self) -> Option<&io::AsyncInputStream> {
+        None
+    }
 }
 
 impl<R: AsyncRead + ?Sized> AsyncRead for &mut R {
     #[inline]
     async fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        (*self).read(buf).await
+        (**self).read(buf).await
     }
 
     #[inline]
     async fn read_to_end(&mut self, buf: &mut Vec<u8>) -> io::Result<usize> {
-        (*self).read_to_end(buf).await
+        (**self).read_to_end(buf).await
+    }
+
+    #[inline]
+    fn as_async_input_stream(&self) -> Option<&io::AsyncInputStream> {
+        (**self).as_async_input_stream()
     }
 }

--- a/src/io/write.rs
+++ b/src/io/write.rs
@@ -16,21 +16,33 @@ pub trait AsyncWrite {
             }
         }
     }
+
+    // If the `AsyncWrite` implementation is an unbuffered wrapper around an
+    // `AsyncOutputStream`, some I/O operations can be more efficient.
+    #[inline]
+    fn as_async_output_stream(&self) -> Option<&io::AsyncOutputStream> {
+        None
+    }
 }
 
 impl<W: AsyncWrite + ?Sized> AsyncWrite for &mut W {
     #[inline]
     async fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        (*self).write(buf).await
+        (**self).write(buf).await
     }
 
     #[inline]
     async fn flush(&mut self) -> io::Result<()> {
-        (*self).flush().await
+        (**self).flush().await
     }
 
     #[inline]
     async fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
-        (*self).write_all(buf).await
+        (**self).write_all(buf).await
+    }
+
+    #[inline]
+    fn as_async_output_stream(&self) -> Option<&io::AsyncOutputStream> {
+        (**self).as_async_output_stream()
     }
 }

--- a/test-programs/artifacts/tests/tcp_echo_server.rs
+++ b/test-programs/artifacts/tests/tcp_echo_server.rs
@@ -77,7 +77,7 @@ fn run_in_wasmtime(wasm: &[u8], stdout: Option<MemoryOutputPipe>) -> Result<()> 
 #[test_log::test]
 fn tcp_echo_server() -> Result<()> {
     use std::io::{Read, Write};
-    use std::net::TcpStream;
+    use std::net::{Shutdown, TcpStream};
     use std::thread::sleep;
     use std::time::Duration;
 

--- a/test-programs/artifacts/tests/tcp_echo_server.rs
+++ b/test-programs/artifacts/tests/tcp_echo_server.rs
@@ -106,6 +106,8 @@ fn tcp_echo_server() -> Result<()> {
     tcpstream.write_all(MESSAGE).context("write to socket")?;
     println!("wrote to echo server");
 
+    tcpstream.shutdown(Shutdown::Write)?;
+
     let mut readback = Vec::new();
     tcpstream
         .read_to_end(&mut readback)


### PR DESCRIPTION
Optimize `wstd::io::copy` using the wasi-io `splice` function. To do this, add a way to query `AsyncRead` and `AsyncWrite` implementations for an underlying `AsyncInputStream` and `AsyncOutputStream`.

This is similar to optimizations done in `std::io::copy`, however those optimizations make use of specialization, which isn't available on stable Rust. That said, using explicit interfaces instead of specialization does have the advantage that user-defined types can opt into optimization if they're able to.

This also eliminates the `RefCell`s in `TcpStream`.