### PR TITLE
Fully encapsulate the underlying WASI types in wstd::time.

### DIFF
--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -87,17 +87,17 @@ impl RequestOptions {
     fn to_wasi(&self) -> Result<WasiRequestOptions> {
         let wasi = WasiRequestOptions::new();
         if let Some(timeout) = self.connect_timeout {
-            wasi.set_connect_timeout(Some(*timeout)).map_err(|()| {
+            wasi.set_connect_timeout(Some(timeout.0)).map_err(|()| {
                 Error::other("wasi-http implementation does not support connect timeout option")
             })?;
         }
         if let Some(timeout) = self.first_byte_timeout {
-            wasi.set_first_byte_timeout(Some(*timeout)).map_err(|()| {
+            wasi.set_first_byte_timeout(Some(timeout.0)).map_err(|()| {
                 Error::other("wasi-http implementation does not support first byte timeout option")
             })?;
         }
         if let Some(timeout) = self.between_bytes_timeout {
-            wasi.set_between_bytes_timeout(Some(*timeout))
+            wasi.set_between_bytes_timeout(Some(timeout.0))
                 .map_err(|()| {
                     Error::other(
                         "wasi-http implementation does not support between byte timeout option",

--- a/src/time/duration.rs
+++ b/src/time/duration.rs
@@ -107,20 +107,6 @@ impl Duration {
     }
 }
 
-impl std::ops::Deref for Duration {
-    type Target = monotonic_clock::Duration;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for Duration {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-
 impl From<std::time::Duration> for Duration {
     fn from(inner: std::time::Duration) -> Self {
         Self(

--- a/src/time/instant.rs
+++ b/src/time/instant.rs
@@ -67,20 +67,6 @@ impl SubAssign<Duration> for Instant {
     }
 }
 
-impl std::ops::Deref for Instant {
-    type Target = monotonic_clock::Instant;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for Instant {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-
 impl IntoFuture for Instant {
     type Output = Instant;
 

--- a/src/time/mod.rs
+++ b/src/time/mod.rs
@@ -61,11 +61,11 @@ impl Timer {
         Timer(None)
     }
     pub fn at(deadline: Instant) -> Timer {
-        let pollable = Reactor::current().schedule(subscribe_instant(*deadline));
+        let pollable = Reactor::current().schedule(subscribe_instant(deadline.0));
         Timer(Some(pollable))
     }
     pub fn after(duration: Duration) -> Timer {
-        let pollable = Reactor::current().schedule(subscribe_duration(*duration));
+        let pollable = Reactor::current().schedule(subscribe_duration(duration.0));
         Timer(Some(pollable))
     }
     pub fn set_after(&mut self, duration: Duration) {


### PR DESCRIPTION
Remove the `Deref`/`DerefMut` implementations from `wstd::time::Instant` and `wstd::time::Duration`. They dereferenced to the raw WASI `monotonic_clock` types, which exposed the raw WASI types in the public API.