### PR TITLE
Reinstate `#![forbid(unsafe_code)]`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ $ cargo add wstd
 ```
 
 ## Safety
-This crate uses ``#![deny(unsafe_code)]`` to ensure everything is implemented in
+This crate uses ``#![forbid(unsafe_code)]`` to ensure everything is implemented in
 100% Safe Rust.
 
 ## Contributing

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![allow(async_fn_in_trait)]
 #![warn(future_incompatible, unreachable_pub)]
+#![forbid(unsafe_code)]
 //#![deny(missing_debug_implementations)]
 //#![warn(missing_docs)]
 //#![forbid(rustdoc::missing_doc_code_examples)]


### PR DESCRIPTION
The README.md advertises that this crate uses `deny(unsafe_code)`; change this to say `forbid(unsafe_code)` assuming this is what was intended, and reinstate the `#![forbid(unsafe_code)]`.

To do this, eliminate an `unsafe` block for creating a noop waker. This requires doing an extra heap allocation for now, though that will go away when `task::Waker::noop` is stabilized.

Another option here would be to just remove the text advertising `unsafe_code` from README.md, and then we could leave the code as-is. I'd be ok with either approach.