### PR TITLE
Re-export http::request::Builder.

### DIFF
--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -138,7 +138,7 @@ pub fn attr_macro_http_server(_attr: TokenStream, item: TokenStream) -> TokenStr
 
                 let responder = ::wstd::http::server::Responder::new(response_out);
                 let _finished: ::wstd::http::server::Finished =
-                    match ::wstd::http::try_from_incoming_request(request)
+                    match ::wstd::http::request::try_from_incoming(request)
                 {
                     Ok(request) => ::wstd::runtime::block_on(async { __run(request, responder).await }),
                     Err(err) => responder.fail(err),

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -9,7 +9,7 @@ pub use client::Client;
 pub use error::{Error, Result};
 pub use fields::{HeaderMap, HeaderName, HeaderValue};
 pub use method::Method;
-pub use request::{try_from_incoming_request, Request};
+pub use request::Request;
 pub use response::Response;
 pub use scheme::{InvalidUri, Scheme};
 
@@ -19,7 +19,7 @@ mod client;
 pub mod error;
 mod fields;
 mod method;
-mod request;
-mod response;
+pub mod request;
+pub mod response;
 mod scheme;
 pub mod server;

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -10,7 +10,7 @@ use crate::io::AsyncInputStream;
 use wasi::http::outgoing_handler::OutgoingRequest;
 use wasi::http::types::IncomingRequest;
 
-pub use http::Request;
+pub use http::request::{Builder, Request};
 
 pub(crate) fn try_into_outgoing<T>(request: Request<T>) -> Result<(OutgoingRequest, T), Error> {
     let wasi_req = OutgoingRequest::new(header_map_to_wasi(request.headers())?);
@@ -54,7 +54,7 @@ pub(crate) fn try_into_outgoing<T>(request: Request<T>) -> Result<(OutgoingReque
 
 /// This is used by the `http_server` macro.
 #[doc(hidden)]
-pub fn try_from_incoming_request(
+pub fn try_from_incoming(
     incoming: IncomingRequest,
 ) -> Result<Request<IncomingBody>, WasiHttpErrorCode> {
     // TODO: What's the right error code to use for invalid headers?

--- a/src/http/response.rs
+++ b/src/http/response.rs
@@ -8,7 +8,7 @@ use super::{
 use crate::io::AsyncInputStream;
 use http::StatusCode;
 
-pub use http::Response;
+pub use http::response::{Builder, Response};
 
 pub(crate) fn try_from_incoming(
     incoming: IncomingResponse,


### PR DESCRIPTION
Re-export http::request::Builder and http::response::Builder. To do this, make the `request` and `response` modules public.