### PR TITLE
Release 0.5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.5.0-draft2"
+version = "0.5.0"
 edition = "2021"
 license = "MIT OR Apache-2.0 OR Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/yoshuawuyts/wstd"
@@ -73,7 +73,7 @@ wasmtime = "26"
 wasmtime-wasi = "26"
 wasmtime-wasi-http = "26"
 wstd = { path = "." }
-wstd-macro = { path = "macro", version = "=0.5.0-draft2" }
+wstd-macro = { path = "macro", version = "=0.5.0" }
 
 [package.metadata.docs.rs]
 targets = [


### PR DESCRIPTION
This PR just bumps the package versions to 0.5.0. Will run the cargo publish locally.

Closes #40 