### PR TITLE
Release 0.5.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 license = "MIT OR Apache-2.0 OR Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/yoshuawuyts/wstd"
@@ -74,7 +74,7 @@ wasmtime = "26"
 wasmtime-wasi = "26"
 wasmtime-wasi-http = "26"
 wstd = { path = "." }
-wstd-macro = { path = "macro", version = "=0.5.0" }
+wstd-macro = { path = "macro", version = "=0.5.1" }
 
 [package.metadata.docs.rs]
 targets = [


### PR DESCRIPTION
the wstd-macro package doesn't need to be bumped, but we are versioning the workspace and its got an = constraint, so its harmless enough to release both