### PR TITLE
adding `.json()` method for better ergonomics similar to `reqwest` crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,8 @@ categories.workspace = true
 repository.workspace = true
 
 [features]
+default = ["json"]
+json = ["dep:serde", "dep:serde_json"]
 
 [dependencies]
 futures-core.workspace = true
@@ -22,11 +24,16 @@ slab.workspace = true
 wasi.workspace = true
 wstd-macro.workspace = true
 
+# optional
+serde = { workspace = true, optional = true }
+serde_json = { workspace = true, optional = true }
+
 [dev-dependencies]
 anyhow.workspace = true
 clap.workspace = true
 futures-lite.workspace = true
 humantime.workspace = true
+serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 
 [workspace]
@@ -62,6 +69,7 @@ http = "1.1"
 itoa = "1"
 pin-project-lite = "0.2.8"
 quote = "1.0"
+serde= "1"
 serde_json = "1"
 slab = "0.4.9"
 syn = "2.0"

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -24,6 +24,12 @@ pub struct Client {
     options: Option<RequestOptions>,
 }
 
+impl Default for Client {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Client {
     /// Create a new instance of `Client`
     pub fn new() -> Self {

--- a/src/http/error.rs
+++ b/src/http/error.rs
@@ -17,7 +17,7 @@ pub use wasi::http::types::{ErrorCode as WasiHttpErrorCode, HeaderError as WasiH
 impl fmt::Debug for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for c in self.context.iter() {
-            write!(f, "in {c}:\n")?;
+            writeln!(f, "in {c}:")?;
         }
         match &self.variant {
             ErrorVariant::WasiHttp(e) => write!(f, "wasi http error: {e:?}"),

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -20,5 +20,5 @@ use std::cell::RefCell;
 // There are no threads in WASI 0.2, so this is just a safe way to thread a single reactor to all
 // use sites in the background.
 std::thread_local! {
-pub(crate) static REACTOR: RefCell<Option<Reactor>> = RefCell::new(None);
+pub(crate) static REACTOR: RefCell<Option<Reactor>> = const { RefCell::new(None) };
 }

--- a/tests/http_get_json.rs
+++ b/tests/http_get_json.rs
@@ -1,0 +1,30 @@
+use serde::Deserialize;
+use std::error::Error;
+use wstd::http::{Client, Request};
+use wstd::io::empty;
+
+#[derive(Deserialize)]
+struct Echo {
+    url: String,
+}
+
+#[wstd::test]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let request = Request::get("https://postman-echo.com/get").body(empty())?;
+
+    let mut response = Client::new().send(request).await?;
+
+    let content_type = response
+        .headers()
+        .get("Content-Type")
+        .ok_or_else(|| "response expected to have Content-Type header")?;
+    assert_eq!(content_type, "application/json; charset=utf-8");
+
+    let Echo { url } = response.body_mut().json::<Echo>().await?;
+    assert!(
+        url.contains("postman-echo.com/get"),
+        "expected body url to contain the authority and path, got: {url}"
+    );
+
+    Ok(())
+}

--- a/tests/http_post_json.rs
+++ b/tests/http_post_json.rs
@@ -1,0 +1,43 @@
+use serde::{Deserialize, Serialize};
+use std::error::Error;
+use wstd::http::{request::JsonRequest, Client, Request};
+
+#[derive(Serialize)]
+struct TestData {
+    test: String,
+}
+
+#[derive(Deserialize)]
+struct Echo {
+    url: String,
+}
+
+#[wstd::test]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let test_data = TestData {
+        test: "data".to_string(),
+    };
+    let request = Request::post("https://postman-echo.com/post").json(&test_data)?;
+
+    let content_type = request
+        .headers()
+        .get("Content-Type")
+        .ok_or_else(|| "request expected to have Content-Type header")?;
+    assert_eq!(content_type, "application/json; charset=utf-8");
+
+    let mut response = Client::new().send(request).await?;
+
+    let content_type = response
+        .headers()
+        .get("Content-Type")
+        .ok_or_else(|| "response expected to have Content-Type header")?;
+    assert_eq!(content_type, "application/json; charset=utf-8");
+
+    let Echo { url } = response.body_mut().json::<Echo>().await?;
+    assert!(
+        url.contains("postman-echo.com/post"),
+        "expected body url to contain the authority and path, got: {url}"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
Improves ergonomics for working with JSON request and responses:
- `response.body_mut().json::<T>().await?;`
- `Request::post("https://postman-echo.com/post").json(&data)?;`