### PR TITLE
bump versions to 0.5.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 license = "MIT OR Apache-2.0 OR Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/yoshuawuyts/wstd"
@@ -82,7 +82,7 @@ wasmtime = "26"
 wasmtime-wasi = "26"
 wasmtime-wasi-http = "26"
 wstd = { path = "." }
-wstd-macro = { path = "macro", version = "=0.5.1" }
+wstd-macro = { path = "macro", version = "=0.5.2" }
 
 [package.metadata.docs.rs]
 targets = [


### PR DESCRIPTION
Changes since 0.5.1 are OK for a patch release:
* https://github.com/yoshuawuyts/wstd/pull/62 Docs improvements
* https://github.com/yoshuawuyts/wstd/pull/63 Adds .json methods and cargo feature (on by default)