### PR TITLE
Prepare to transfer this repository to the `bytecodealliance` github org

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,50 @@
+# Contributor Covenant Code of Conduct
+
+*Note*: this Code of Conduct pertains to individuals' behavior. Please also see the [Organizational Code of Conduct][OCoC]. Additionally, individuals must also adhere to the [Bytecode Alliance Code of Conduct][BACoC].
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the Bytecode Alliance CoC team at [report@bytecodealliance.org](mailto:report@bytecodealliance.org). The CoC team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The CoC team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the Bytecode Alliance's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]
+
+[OCoC]: https://github.com/bytecodealliance/wasmtime/blob/main/ORG_CODE_OF_CONDUCT.md
+[BACoC]: https://github.com/bytecodealliance/governance/blob/main/CODE_OF_CONDUCT.md
+[homepage]: https://www.contributor-covenant.org
+[version]: https://www.contributor-covenant.org/version/1/4/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,33 @@
+# Contributing to wstd
+
+Wstd is a [Bytecode Alliance] project. It follows the Bytecode Alliance's
+[Code of Conduct] and [Organizational Code of Conduct].
+
+[Bytecode Alliance]: https://bytecodealliance.org/
+[Code of Conduct]: CODE_OF_CONDUCT.md
+[Organizational Code of Conduct]: ORG_CODE_OF_CONDUCT.md
+
+## File an Issue
+
+Please [file an issue] to report bugs in wstd. Please provide the smallest
+reasonable context to reproduce your bug. If you cannot share the context of
+your bug, you may still open a bug, but we may end up needing to close it if
+you can't provide a way to reproduce.
+
+Please [file an issue] if the [rust docs] or [examples] are incomplete, ambigious,
+misleading, or incorrect.
+
+Before creating a nontrivial PR to wstd, we suggest you first [file an issue]
+to propose and discuss the change.
+
+[file an issue]: https://github.com/yoshuawuyts/wstd/issues
+[rust docs]: https://docs.rs/wstd/latest/wstd
+[examples]: https://github.com/yoshuawuyts/wstd/tree/main/examples
+
+## Join Our Chat
+
+We chat about wstd development on the Bytecode Alliance Zulip -- [join us!][zulip]. You
+can also join the [wstd stream] directly.
+
+[zulip]: https://bytecodealliance.zulipchat.com/
+[wstd stream]: https://bytecodealliance.zulipchat.com/#narrow/channel/514491-wstd


### PR DESCRIPTION
* add CODE_OF_CONDUCT: copied directly from wasmtime.
* add CONTRIBUTING: suggests zulip, and the bug tracker