### PR TITLE
Fix `#[wstd::test]` macro hygiene

### DIFF
--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -68,7 +68,7 @@ pub fn attr_macro_test(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let output = input.sig.output;
     let block = input.block;
     quote! {
-        #[test]
+        #[::core::prelude::v1::test]
         pub fn #name() #output {
 
             #(#attrs)*


### PR DESCRIPTION
Using an unqualified `#[test]` in the generated code could lead to macro hygiene problems...

Fixes #74