### PR TITLE
switch from using `wasi` crate to `wasip2`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ http.workspace = true
 itoa.workspace = true
 pin-project-lite.workspace = true
 slab.workspace = true
-wasi.workspace = true
+wasip2.workspace = true
 wstd-macro.workspace = true
 
 # optional
@@ -83,7 +83,7 @@ test-log = { version = "0.2", features = ["trace"] }
 test-programs = { path = "test-programs" }
 test-programs-artifacts = { path = "test-programs/artifacts" }
 ureq = { version = "2.12.1", default-features = false }
-wasi = "0.14.0"
+wasip2 = "1.0"
 wstd = { path = "." }
 wstd-macro = { path = "macro", version = "=0.5.5" }
 

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -126,10 +126,10 @@ pub fn attr_macro_http_server(_attr: TokenStream, item: TokenStream) -> TokenStr
     quote! {
         struct TheServer;
 
-        impl ::wstd::wasi::exports::http::incoming_handler::Guest for TheServer {
+        impl ::wstd::wasip2::exports::http::incoming_handler::Guest for TheServer {
             fn handle(
-                request: ::wstd::wasi::http::types::IncomingRequest,
-                response_out: ::wstd::wasi::http::types::ResponseOutparam
+                request: ::wstd::wasip2::http::types::IncomingRequest,
+                response_out: ::wstd::wasip2::http::types::ResponseOutparam
             ) {
                 #(#attrs)*
                 #vis async fn __run(#inputs) #output {
@@ -146,7 +146,7 @@ pub fn attr_macro_http_server(_attr: TokenStream, item: TokenStream) -> TokenStr
             }
         }
 
-        ::wstd::wasi::http::proxy::export!(TheServer with_types_in ::wstd::wasi);
+        ::wstd::wasip2::http::proxy::export!(TheServer with_types_in ::wstd::wasip2);
 
         // Provide an actual function named `main`.
         //

--- a/src/http/body.rs
+++ b/src/http/body.rs
@@ -5,7 +5,7 @@ use crate::io::{AsyncInputStream, AsyncOutputStream, AsyncRead, AsyncWrite, Curs
 use crate::runtime::AsyncPollable;
 use core::fmt;
 use http::header::CONTENT_LENGTH;
-use wasi::http::types::IncomingBody as WasiIncomingBody;
+use wasip2::http::types::IncomingBody as WasiIncomingBody;
 
 #[cfg(feature = "json")]
 use serde::de::DeserializeOwned;
@@ -274,12 +274,12 @@ pub struct OutgoingBody {
     // IMPORTANT: the order of these fields here matters. `stream` must
     // be dropped before `body`.
     stream: AsyncOutputStream,
-    body: wasi::http::types::OutgoingBody,
+    body: wasip2::http::types::OutgoingBody,
     dontdrop: DontDropOutgoingBody,
 }
 
 impl OutgoingBody {
-    pub(crate) fn new(stream: AsyncOutputStream, body: wasi::http::types::OutgoingBody) -> Self {
+    pub(crate) fn new(stream: AsyncOutputStream, body: wasip2::http::types::OutgoingBody) -> Self {
         Self {
             stream,
             body,
@@ -287,7 +287,7 @@ impl OutgoingBody {
         }
     }
 
-    pub(crate) fn consume(self) -> (AsyncOutputStream, wasi::http::types::OutgoingBody) {
+    pub(crate) fn consume(self) -> (AsyncOutputStream, wasip2::http::types::OutgoingBody) {
         let Self {
             stream,
             body,

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -12,7 +12,7 @@ use pin_project_lite::pin_project;
 use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
-use wasi::http::types::{
+use wasip2::http::types::{
     FutureIncomingResponse as WasiFutureIncomingResponse, OutgoingBody as WasiOutgoingBody,
     RequestOptions as WasiRequestOptions,
 };
@@ -50,7 +50,7 @@ impl Client {
         let wasi_stream = wasi_body.write().unwrap();
 
         // 1. Start sending the request head
-        let res = wasi::http::outgoing_handler::handle(wasi_req, self.wasi_options()?).unwrap();
+        let res = wasip2::http::outgoing_handler::handle(wasi_req, self.wasi_options()?).unwrap();
 
         // 2. Start sending the request body
         io::copy(body, AsyncOutputStream::new(wasi_stream)).await?;
@@ -86,7 +86,7 @@ impl Client {
         let wasi_stream = wasi_body.write().unwrap();
 
         // Start sending the request head.
-        let res = wasi::http::outgoing_handler::handle(wasi_req, self.wasi_options()?).unwrap();
+        let res = wasip2::http::outgoing_handler::handle(wasi_req, self.wasi_options()?).unwrap();
 
         let outgoing_body = OutgoingBody::new(AsyncOutputStream::new(wasi_stream), wasi_body);
 
@@ -141,7 +141,7 @@ impl Client {
             None => None,
         };
 
-        wasi::http::types::OutgoingBody::finish(body, wasi_trailers)
+        wasip2::http::types::OutgoingBody::finish(body, wasi_trailers)
             .expect("body length did not match Content-Length header value");
         Ok(())
     }

--- a/src/http/error.rs
+++ b/src/http/error.rs
@@ -12,7 +12,7 @@ pub struct Error {
 
 pub use http::header::{InvalidHeaderName, InvalidHeaderValue};
 pub use http::method::InvalidMethod;
-pub use wasi::http::types::{ErrorCode as WasiHttpErrorCode, HeaderError as WasiHttpHeaderError};
+pub use wasip2::http::types::{ErrorCode as WasiHttpErrorCode, HeaderError as WasiHttpHeaderError};
 
 impl fmt::Debug for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/http/fields.rs
+++ b/src/http/fields.rs
@@ -1,7 +1,7 @@
 pub use http::header::{HeaderMap, HeaderName, HeaderValue};
 
 use super::Error;
-use wasi::http::types::{Fields, HeaderError as WasiHttpHeaderError};
+use wasip2::http::types::{Fields, HeaderError as WasiHttpHeaderError};
 
 pub(crate) fn header_map_from_wasi(wasi_fields: Fields) -> Result<HeaderMap, Error> {
     let mut output = HeaderMap::new();

--- a/src/http/method.rs
+++ b/src/http/method.rs
@@ -1,4 +1,4 @@
-use wasi::http::types::Method as WasiMethod;
+use wasip2::http::types::Method as WasiMethod;
 
 use http::method::InvalidMethod;
 pub use http::Method;

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -7,8 +7,8 @@ use super::{
     Authority, Error, HeaderMap, PathAndQuery, Uri,
 };
 use crate::io::AsyncInputStream;
-use wasi::http::outgoing_handler::OutgoingRequest;
-use wasi::http::types::IncomingRequest;
+use wasip2::http::outgoing_handler::OutgoingRequest;
+use wasip2::http::types::IncomingRequest;
 
 pub use http::request::{Builder, Request};
 
@@ -71,7 +71,7 @@ pub(crate) fn try_into_outgoing<T>(request: Request<T>) -> Result<(OutgoingReque
         .uri
         .scheme()
         .map(to_wasi_scheme)
-        .unwrap_or(wasi::http::types::Scheme::Https);
+        .unwrap_or(wasip2::http::types::Scheme::Https);
     wasi_req
         .set_scheme(Some(&scheme))
         .map_err(|()| Error::other(format!("scheme rejected by wasi-http: {scheme:?}")))?;

--- a/src/http/response.rs
+++ b/src/http/response.rs
@@ -1,4 +1,4 @@
-use wasi::http::types::IncomingResponse;
+use wasip2::http::types::IncomingResponse;
 
 use super::{
     body::{BodyKind, IncomingBody},

--- a/src/http/scheme.rs
+++ b/src/http/scheme.rs
@@ -1,4 +1,4 @@
-use wasi::http::types::Scheme as WasiScheme;
+use wasip2::http::types::Scheme as WasiScheme;
 
 pub use http::uri::{InvalidUri, Scheme};
 use std::str::FromStr;

--- a/src/http/server.rs
+++ b/src/http/server.rs
@@ -28,8 +28,8 @@ use super::{
 };
 use crate::io::{copy, AsyncOutputStream};
 use http::header::CONTENT_LENGTH;
-use wasi::exports::http::incoming_handler::ResponseOutparam;
-use wasi::http::types::OutgoingResponse;
+use wasip2::exports::http::incoming_handler::ResponseOutparam;
+use wasip2::http::types::OutgoingResponse;
 
 /// This is passed into the [`http_server`] `main` function and holds the state
 /// needed for a handler to produce a response, or fail. There are two ways to
@@ -179,7 +179,7 @@ impl Finished {
         let wasi_trailers =
             trailers.map(|trailers| header_map_to_wasi(&trailers).expect("header error"));
 
-        wasi::http::types::OutgoingBody::finish(body, wasi_trailers)
+        wasip2::http::types::OutgoingBody::finish(body, wasi_trailers)
             .expect("body length did not match Content-Length header value");
 
         Self(())

--- a/src/io/copy.rs
+++ b/src/io/copy.rs
@@ -1,5 +1,5 @@
 use crate::io::{AsyncRead, AsyncWrite, Error};
-use wasi::io::streams::StreamError;
+use wasip2::io::streams::StreamError;
 
 /// Copy bytes from a reader to a writer.
 pub async fn copy<R, W>(mut reader: R, mut writer: W) -> crate::io::Result<()>

--- a/src/io/stdio.rs
+++ b/src/io/stdio.rs
@@ -1,7 +1,7 @@
 use super::{AsyncInputStream, AsyncOutputStream, AsyncRead, AsyncWrite, Result};
 use std::cell::LazyCell;
-use wasi::cli::terminal_input::TerminalInput;
-use wasi::cli::terminal_output::TerminalOutput;
+use wasip2::cli::terminal_input::TerminalInput;
+use wasip2::cli::terminal_output::TerminalOutput;
 
 /// Use the program's stdin as an `AsyncInputStream`.
 #[derive(Debug)]
@@ -12,10 +12,10 @@ pub struct Stdin {
 
 /// Get the program's stdin for use as an `AsyncInputStream`.
 pub fn stdin() -> Stdin {
-    let stream = AsyncInputStream::new(wasi::cli::stdin::get_stdin());
+    let stream = AsyncInputStream::new(wasip2::cli::stdin::get_stdin());
     Stdin {
         stream,
-        terminput: LazyCell::new(wasi::cli::terminal_stdin::get_terminal_stdin),
+        terminput: LazyCell::new(wasip2::cli::terminal_stdin::get_terminal_stdin),
     }
 }
 
@@ -52,10 +52,10 @@ pub struct Stdout {
 
 /// Get the program's stdout for use as an `AsyncOutputStream`.
 pub fn stdout() -> Stdout {
-    let stream = AsyncOutputStream::new(wasi::cli::stdout::get_stdout());
+    let stream = AsyncOutputStream::new(wasip2::cli::stdout::get_stdout());
     Stdout {
         stream,
-        termoutput: LazyCell::new(wasi::cli::terminal_stdout::get_terminal_stdout),
+        termoutput: LazyCell::new(wasip2::cli::terminal_stdout::get_terminal_stdout),
     }
 }
 
@@ -97,10 +97,10 @@ pub struct Stderr {
 
 /// Get the program's stdout for use as an `AsyncOutputStream`.
 pub fn stderr() -> Stderr {
-    let stream = AsyncOutputStream::new(wasi::cli::stderr::get_stderr());
+    let stream = AsyncOutputStream::new(wasip2::cli::stderr::get_stderr());
     Stderr {
         stream,
-        termoutput: LazyCell::new(wasi::cli::terminal_stderr::get_terminal_stderr),
+        termoutput: LazyCell::new(wasip2::cli::terminal_stderr::get_terminal_stderr),
     }
 }
 

--- a/src/io/streams.rs
+++ b/src/io/streams.rs
@@ -1,7 +1,7 @@
 use super::{AsyncPollable, AsyncRead, AsyncWrite};
 use std::cell::OnceCell;
 use std::io::Result;
-use wasi::io::streams::{InputStream, OutputStream, StreamError};
+use wasip2::io::streams::{InputStream, OutputStream, StreamError};
 
 /// A wrapper for WASI's `InputStream` resource that provides implementations of `AsyncRead` and
 /// `AsyncPollable`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,7 @@ pub use wstd_macro::attr_macro_test as test;
 
 // Re-export the wasi crate for use by the `http_server` macro.
 #[doc(hidden)]
-pub use wasi;
+pub use wasip2;
 
 pub mod prelude {
     pub use crate::future::FutureExt as _;

--- a/src/net/tcp_listener.rs
+++ b/src/net/tcp_listener.rs
@@ -1,5 +1,5 @@
-use wasi::sockets::network::Ipv4SocketAddress;
-use wasi::sockets::tcp::{ErrorCode, IpAddressFamily, IpSocketAddress, TcpSocket};
+use wasip2::sockets::network::Ipv4SocketAddress;
+use wasip2::sockets::tcp::{ErrorCode, IpAddressFamily, IpSocketAddress, TcpSocket};
 
 use crate::io;
 use crate::iter::AsyncIterator;
@@ -30,8 +30,8 @@ impl TcpListener {
             SocketAddr::V6(_) => IpAddressFamily::Ipv6,
         };
         let socket =
-            wasi::sockets::tcp_create_socket::create_tcp_socket(family).map_err(to_io_err)?;
-        let network = wasi::sockets::instance_network::instance_network();
+            wasip2::sockets::tcp_create_socket::create_tcp_socket(family).map_err(to_io_err)?;
+        let network = wasip2::sockets::instance_network::instance_network();
 
         let local_address = sockaddr_to_wasi(addr);
 
@@ -83,25 +83,29 @@ impl<'a> AsyncIterator for Incoming<'a> {
 
 pub(super) fn to_io_err(err: ErrorCode) -> io::Error {
     match err {
-        wasi::sockets::network::ErrorCode::Unknown => ErrorKind::Other.into(),
-        wasi::sockets::network::ErrorCode::AccessDenied => ErrorKind::PermissionDenied.into(),
-        wasi::sockets::network::ErrorCode::NotSupported => ErrorKind::Unsupported.into(),
-        wasi::sockets::network::ErrorCode::InvalidArgument => ErrorKind::InvalidInput.into(),
-        wasi::sockets::network::ErrorCode::OutOfMemory => ErrorKind::OutOfMemory.into(),
-        wasi::sockets::network::ErrorCode::Timeout => ErrorKind::TimedOut.into(),
-        wasi::sockets::network::ErrorCode::WouldBlock => ErrorKind::WouldBlock.into(),
-        wasi::sockets::network::ErrorCode::InvalidState => ErrorKind::InvalidData.into(),
-        wasi::sockets::network::ErrorCode::AddressInUse => ErrorKind::AddrInUse.into(),
-        wasi::sockets::network::ErrorCode::ConnectionRefused => ErrorKind::ConnectionRefused.into(),
-        wasi::sockets::network::ErrorCode::ConnectionReset => ErrorKind::ConnectionReset.into(),
-        wasi::sockets::network::ErrorCode::ConnectionAborted => ErrorKind::ConnectionAborted.into(),
-        wasi::sockets::network::ErrorCode::ConcurrencyConflict => ErrorKind::AlreadyExists.into(),
+        wasip2::sockets::network::ErrorCode::Unknown => ErrorKind::Other.into(),
+        wasip2::sockets::network::ErrorCode::AccessDenied => ErrorKind::PermissionDenied.into(),
+        wasip2::sockets::network::ErrorCode::NotSupported => ErrorKind::Unsupported.into(),
+        wasip2::sockets::network::ErrorCode::InvalidArgument => ErrorKind::InvalidInput.into(),
+        wasip2::sockets::network::ErrorCode::OutOfMemory => ErrorKind::OutOfMemory.into(),
+        wasip2::sockets::network::ErrorCode::Timeout => ErrorKind::TimedOut.into(),
+        wasip2::sockets::network::ErrorCode::WouldBlock => ErrorKind::WouldBlock.into(),
+        wasip2::sockets::network::ErrorCode::InvalidState => ErrorKind::InvalidData.into(),
+        wasip2::sockets::network::ErrorCode::AddressInUse => ErrorKind::AddrInUse.into(),
+        wasip2::sockets::network::ErrorCode::ConnectionRefused => {
+            ErrorKind::ConnectionRefused.into()
+        }
+        wasip2::sockets::network::ErrorCode::ConnectionReset => ErrorKind::ConnectionReset.into(),
+        wasip2::sockets::network::ErrorCode::ConnectionAborted => {
+            ErrorKind::ConnectionAborted.into()
+        }
+        wasip2::sockets::network::ErrorCode::ConcurrencyConflict => ErrorKind::AlreadyExists.into(),
         _ => ErrorKind::Other.into(),
     }
 }
 
 fn sockaddr_from_wasi(addr: IpSocketAddress) -> std::net::SocketAddr {
-    use wasi::sockets::network::Ipv6SocketAddress;
+    use wasip2::sockets::network::Ipv6SocketAddress;
     match addr {
         IpSocketAddress::Ipv4(Ipv4SocketAddress { address, port }) => {
             std::net::SocketAddr::V4(std::net::SocketAddrV4::new(
@@ -127,7 +131,7 @@ fn sockaddr_from_wasi(addr: IpSocketAddress) -> std::net::SocketAddr {
 }
 
 fn sockaddr_to_wasi(addr: std::net::SocketAddr) -> IpSocketAddress {
-    use wasi::sockets::network::Ipv6SocketAddress;
+    use wasip2::sockets::network::Ipv6SocketAddress;
     match addr {
         std::net::SocketAddr::V4(addr) => {
             let ip = addr.ip().octets();

--- a/src/net/tcp_stream.rs
+++ b/src/net/tcp_stream.rs
@@ -1,4 +1,4 @@
-use wasi::{
+use wasip2::{
     io::streams::{InputStream, OutputStream},
     sockets::tcp::TcpSocket,
 };
@@ -36,7 +36,9 @@ impl TcpStream {
 
 impl Drop for TcpStream {
     fn drop(&mut self) {
-        let _ = self.socket.shutdown(wasi::sockets::tcp::ShutdownType::Both);
+        let _ = self
+            .socket
+            .shutdown(wasip2::sockets::tcp::ShutdownType::Both);
     }
 }
 
@@ -104,7 +106,7 @@ impl<'a> Drop for ReadHalf<'a> {
         let _ = self
             .0
             .socket
-            .shutdown(wasi::sockets::tcp::ShutdownType::Receive);
+            .shutdown(wasip2::sockets::tcp::ShutdownType::Receive);
     }
 }
 
@@ -128,6 +130,6 @@ impl<'a> Drop for WriteHalf<'a> {
         let _ = self
             .0
             .socket
-            .shutdown(wasi::sockets::tcp::ShutdownType::Send);
+            .shutdown(wasip2::sockets::tcp::ShutdownType::Send);
     }
 }

--- a/src/rand/mod.rs
+++ b/src/rand/mod.rs
@@ -1,6 +1,6 @@
 //! Random number generation.
 
-use wasi::random;
+use wasip2::random;
 
 /// Fill the slice with cryptographically secure random bytes.
 pub fn get_random_bytes(buf: &mut [u8]) {

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -3,7 +3,7 @@
 //! The way to use this is to call [`block_on()`]. Inside the future, [`Reactor::current`]
 //! will give an instance of the [`Reactor`] running the event loop, which can be
 //! to [`AsyncPollable::wait_for`] instances of
-//! [`wasi::Pollable`](https://docs.rs/wasi/latest/wasi/io/poll/struct.Pollable.html).
+//! [`wasip2::Pollable`](https://docs.rs/wasi/latest/wasi/io/poll/struct.Pollable.html).
 //! This will automatically wait for the futures to resolve, and call the
 //! necessary wakers to work.
 

--- a/src/time/duration.rs
+++ b/src/time/duration.rs
@@ -1,7 +1,7 @@
 use super::{Instant, Wait};
 use std::future::IntoFuture;
 use std::ops::{Add, AddAssign, Sub, SubAssign};
-use wasi::clocks::monotonic_clock;
+use wasip2::clocks::monotonic_clock;
 
 /// A Duration type to represent a span of time, typically used for system
 /// timeouts.

--- a/src/time/instant.rs
+++ b/src/time/instant.rs
@@ -1,7 +1,7 @@
 use super::{Duration, Wait};
 use std::future::IntoFuture;
 use std::ops::{Add, AddAssign, Sub, SubAssign};
-use wasi::clocks::monotonic_clock;
+use wasip2::clocks::monotonic_clock;
 
 /// A measurement of a monotonically nondecreasing clock. Opaque and useful only
 /// with Duration.
@@ -24,7 +24,7 @@ impl Instant {
     /// ```
     #[must_use]
     pub fn now() -> Self {
-        Instant(wasi::clocks::monotonic_clock::now())
+        Instant(wasip2::clocks::monotonic_clock::now())
     }
 
     /// Returns the amount of time elapsed from another instant to this one, or zero duration if

--- a/src/time/mod.rs
+++ b/src/time/mod.rs
@@ -11,7 +11,7 @@ use pin_project_lite::pin_project;
 use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
-use wasi::clocks::{
+use wasip2::clocks::{
     monotonic_clock::{subscribe_duration, subscribe_instant},
     wall_clock,
 };


### PR DESCRIPTION
As of https://github.com/bytecodealliance/wasi-rs/pull/118, the `wasi` crate is just a facade to the `wasip2` crate. Instead of depending on the facade, use `wasip2` directly, in anticipation that we will one day soon use `wasip3` as well behind the appropriate cfg.