### PR TITLE
SystemTime::duration_since and UNIX_EPOCH

### DIFF
--- a/src/time/mod.rs
+++ b/src/time/mod.rs
@@ -37,7 +37,7 @@ impl SystemTime {
         Self(wall_clock::now())
     }
 
-    pub fn duration_since(&self, earlier: &SystemTime) -> Result<Duration, SystemTimeError> {
+    pub fn duration_since(&self, earlier: SystemTime) -> Result<Duration, SystemTimeError> {
         if self.0.seconds >= earlier.0.seconds && self.0.nanoseconds >= earlier.0.nanoseconds {
             return Ok(Duration::new(
                 self.0.seconds - earlier.0.seconds,
@@ -49,6 +49,7 @@ impl SystemTime {
     }
 }
 
+#[derive(Debug, Clone, Copy)]
 pub struct SystemTimeError;
 
 /// An async iterator representing notifications at fixed interval.
@@ -137,9 +138,9 @@ mod test {
             let earlier = SystemTime::UNIX_EPOCH;
             let now = SystemTime::now();
 
-            assert!(now.duration_since(&earlier).is_ok());
-            assert!(now.duration_since(&now).is_ok_and(|x| x.as_secs() == 0));
-            assert!(earlier.duration_since(&now).is_err());
+            assert!(now.duration_since(earlier).is_ok());
+            assert!(now.duration_since(now).is_ok_and(|x| x.as_secs() == 0));
+            assert!(earlier.duration_since(now).is_err());
         });
     }
 


### PR DESCRIPTION
My primary goal here is to make it easy for me to calculate UNIX_EPOCH.

Technically the easiest way to do this would be to extract it from SystemTime's internal DateTime structure; that was my initial approach. 

I opted instead to give SystemTime a similar look and feel to the standard library though I did take a bit of a shortcut with SystemTimeError(I'm not actually sure what would happen on overflow).