### PR TITLE
wasi-http: don't send forbidden headers

### DIFF
--- a/src/http/fields.rs
+++ b/src/http/fields.rs
@@ -18,10 +18,25 @@ pub(crate) fn header_map_from_wasi(wasi_fields: Fields) -> Result<HeaderMap, Err
 pub(crate) fn header_map_to_wasi(header_map: &HeaderMap) -> Result<Fields, Error> {
     let wasi_fields = Fields::new();
     for (key, value) in header_map {
-        // Unwrap because `HeaderMap` has already validated the headers.
-        wasi_fields
-            .append(key.as_str(), value.as_bytes())
-            .with_context(|| format!("wasi rejected header `{key}: {value:?}`"))?
+        if !FORBIDDEN_HEADERS.contains(key) {
+            wasi_fields
+                .append(key.as_str(), value.as_bytes())
+                .with_context(|| format!("wasi rejected header `{key}: {value:?}`"))?
+        }
     }
     Ok(wasi_fields)
 }
+
+const FORBIDDEN_HEADERS: [HeaderName; 11] = [
+    http::header::CONNECTION,
+    HeaderName::from_static("keep-alive"),
+    http::header::PROXY_AUTHENTICATE,
+    http::header::PROXY_AUTHORIZATION,
+    HeaderName::from_static("proxy-connection"),
+    http::header::TRANSFER_ENCODING,
+    http::header::UPGRADE,
+    http::header::HOST,
+    HeaderName::from_static("http2-settings"),
+    http::header::EXPECT,
+    http::header::CONTENT_LENGTH,
+];

--- a/src/http/fields.rs
+++ b/src/http/fields.rs
@@ -18,7 +18,12 @@ pub(crate) fn header_map_from_wasi(wasi_fields: Fields) -> Result<HeaderMap, Err
 pub(crate) fn header_map_to_wasi(header_map: &HeaderMap) -> Result<Fields, Error> {
     let wasi_fields = Fields::new();
     for (key, value) in header_map {
-        if !FORBIDDEN_HEADERS.contains(key) {
+        let key = key.as_str().to_ascii_lowercase();
+        if FORBIDDEN_HEADERS
+            .iter()
+            .find(|k| k.as_str() == key)
+            .is_none()
+        {
             wasi_fields
                 .append(key.as_str(), value.as_bytes())
                 .with_context(|| format!("wasi rejected header `{key}: {value:?}`"))?
@@ -27,6 +32,7 @@ pub(crate) fn header_map_to_wasi(header_map: &HeaderMap) -> Result<Fields, Error
     Ok(wasi_fields)
 }
 
+// Optimization opportunity: use a trie here
 const FORBIDDEN_HEADERS: [HeaderName; 11] = [
     http::header::CONNECTION,
     HeaderName::from_static("keep-alive"),

--- a/src/http/server.rs
+++ b/src/http/server.rs
@@ -19,7 +19,6 @@
 //! [`http_server`]: crate::http_server
 
 use super::{Body, Error, Response, error::ErrorCode, fields::header_map_to_wasi};
-use http::header::CONTENT_LENGTH;
 use wasip2::exports::http::incoming_handler::ResponseOutparam;
 use wasip2::http::types::OutgoingResponse;
 
@@ -43,14 +42,6 @@ impl Responder {
 
         // Consume the `response` and prepare to write the body.
         let body = response.into_body().into();
-
-        // Automatically add a Content-Length header.
-        if let Some(len) = body.content_length() {
-            let mut buffer = itoa::Buffer::new();
-            wasi_headers
-                .append(CONTENT_LENGTH.as_str(), buffer.format(len).as_bytes())
-                .unwrap();
-        }
 
         let wasi_response = OutgoingResponse::new(wasi_headers);
 


### PR DESCRIPTION
Everyone agrees wasi shouldnt use forbidden headers, but nobody agrees on what they are (yet) https://github.com/WebAssembly/WASI/issues/940.

This PR takes the default wasmtime set, and adds Content-Length and Expect as forbidden headers. Because `HeaderMap` doesn't provide us a mechanism to forbid headers, we instead just silently drop any of the known forbidden headers when translating to a wasi `fields` resource.

The set of forbidden headers is:
* Connection
* Keep-Alive
* Proxy-Authenticate
* Proxy-Authorization
* Proxy-Connection
* Transfer-Encoding
* Upgrade
* Host
* Http2-Settings
* Expect
* Content-Length

Since this is a pretty significant behavioral change, we will bump the version to 0.7.0 for the next release after this lands.
