### PR TITLE
http server: don't automatically add a content-length header

### DIFF
--- a/src/http/server.rs
+++ b/src/http/server.rs
@@ -19,7 +19,6 @@
 //! [`http_server`]: crate::http_server
 
 use super::{Body, Error, Response, error::ErrorCode, fields::header_map_to_wasi};
-use http::header::CONTENT_LENGTH;
 use wasip2::exports::http::incoming_handler::ResponseOutparam;
 use wasip2::http::types::OutgoingResponse;
 
@@ -43,14 +42,6 @@ impl Responder {
 
         // Consume the `response` and prepare to write the body.
         let body = response.into_body().into();
-
-        // Automatically add a Content-Length header.
-        if let Some(len) = body.content_length() {
-            let mut buffer = itoa::Buffer::new();
-            wasi_headers
-                .append(CONTENT_LENGTH.as_str(), buffer.format(len).as_bytes())
-                .unwrap();
-        }
 
         let wasi_response = OutgoingResponse::new(wasi_headers);
 


### PR DESCRIPTION
This behavior might not work on some wasi-http runtimes, since restricted headers are not specified.

In particular, content-length is a header that is http1 specific - in http2 and 3 framing is handled differently. But even in http1, its making a decision about framing that the imported http implementation may not agree with, e.g. there could be an implementation that insists on always sending chunked transfer encoding, and by setting content-length all the time it means that either wstd will always unwrap on a `forbidden` error here, or the implementation has to silently filter out that header. Neither of those alternatives serve wstd's users well.